### PR TITLE
feat: validate only requested keys for session_stats comparison

### DIFF
--- a/docs/panos-upgrade-assurance/api/snapshot_compare.md
+++ b/docs/panos-upgrade-assurance/api/snapshot_compare.md
@@ -100,19 +100,20 @@ __Returns__
 
 ```python
 @staticmethod
-def key_checker(left_dict: dict, right_dict: dict, key: str) -> None
+def key_checker(left_dict: dict, right_dict: dict, key: Union[str, set,
+                                                              list]) -> None
 ```
 
-The static method to check if a key is available in both dictionaries.
+The static method to check if a key or a list/set of keys is available in both dictionaries.
 
-This method looks for a given key in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
+This method looks for a given key or list/set of keys in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
 
 __Parameters__
 
 
 - __left_dict__ (`dict`): 1st dictionary to verify.
 - __right_dict__ (`dict`): 2nd dictionary to verify.
-- __key__ (`str`): Key name to check.
+- __key__ (`str, set, list`): Key name or set/list of keys to check.
 
 __Raises__
 

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -130,7 +130,7 @@ class SnapshotCompare:
 
     @staticmethod
     def key_checker(left_dict: dict, right_dict: dict, key: Union[str, set, list]) -> None:
-        """The static method to check if a key(string) or list/set of keys is available in both dictionaries.
+        """The static method to check if a key or a list/set of keys is available in both dictionaries.
 
         This method looks for a given key or list/set of keys in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
 

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -129,30 +129,38 @@ class SnapshotCompare:
         return result
 
     @staticmethod
-    def key_checker(left_dict: dict, right_dict: dict, key: str) -> None:
-        """The static method to check if a key is available in both dictionaries.
+    def key_checker(left_dict: dict, right_dict: dict, key: Union[str, set, list]) -> None:
+        """The static method to check if a key(string) or list/set of keys is available in both dictionaries.
 
-        This method looks for a given key in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
+        This method looks for a given key or list/set of keys in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
 
         # Parameters
 
         left_dict (dict): 1st dictionary to verify.
         right_dict (dict): 2nd dictionary to verify.
-        key (str): Key name to check.
+        key (str, set, list): Key name or set/list of keys to check.
 
         # Raises
 
         MissingKeyException: when key is not available in at least one snapshot.
 
         """
-        left_snap_missing_key = False if key in left_dict else True
-        right_snap_missing_key = False if key in right_dict else True
+
+        if isinstance(key, str):
+            key_set = [key]
+        elif isinstance(key, (set, list)):
+            key_set = key
+        else:
+            raise WrongDataTypeException(f'The key variable is a {type(key)} but should be either str, set or list')
+
+        left_snap_missing_key = False if set(key_set).issubset(left_dict.keys()) else True
+        right_snap_missing_key = False if set(key_set).issubset(right_dict.keys()) else True
 
         if left_snap_missing_key and right_snap_missing_key:
-            raise MissingKeyException(f"{key} is missing in both snapshots")
+            raise MissingKeyException(f"{key} (some elements if set/list) is missing in both snapshots")
         if left_snap_missing_key or right_snap_missing_key:
             raise MissingKeyException(
-                f"{key} is missing in {'left snapshot' if left_snap_missing_key else 'right snapshot'}"
+                f"{key} (some elements if set/list) is missing in {'left snapshot' if left_snap_missing_key else 'right snapshot'}"
             )
 
     @staticmethod
@@ -693,10 +701,12 @@ class SnapshotCompare:
             passed=True,
         )
 
-        if self.left_snap[report_type].keys() != self.right_snap[report_type].keys():
+        requested_elements = set(next(iter(unary_dict)) for unary_dict in thresholds)
+        try:
+            self.key_checker(self.left_snap[report_type], self.right_snap[report_type], requested_elements)
+        except MissingKeyException as exc:  # raised when any requested key is missing in one of the snapshots
             raise SnapshotSchemeMismatchException(
-                f"Snapshots contain different set of data for {report_type} report."
-            )
+                f'Snapshots have missing keys in {requested_elements} for {report_type} report.') from exc
 
         elements = ConfigParser(
             valid_elements=set(self.left_snap[report_type].keys()),
@@ -705,9 +715,6 @@ class SnapshotCompare:
 
         for element in elements:
             element_type, threshold_value = list(element.items())[0]
-            self.key_checker(
-                self.left_snap[report_type], self.right_snap[report_type], element_type
-            )
             result.update(
                 {
                     element_type: SnapshotCompare.calculate_change_percentage(

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -151,7 +151,7 @@ class SnapshotCompare:
         elif isinstance(key, (set, list)):
             key_set = key
         else:
-            raise WrongDataTypeException(f'The key variable is a {type(key)} but should be either str, set or list')
+            raise WrongDataTypeException(f'The key variable is a {type(key)} but should be either: str, set or list')
 
         left_snap_missing_key = False if set(key_set).issubset(left_dict.keys()) else True
         right_snap_missing_key = False if set(key_set).issubset(right_dict.keys()) else True

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -129,7 +129,9 @@ class SnapshotCompare:
         return result
 
     @staticmethod
-    def key_checker(left_dict: dict, right_dict: dict, key: Union[str, set, list]) -> None:
+    def key_checker(
+        left_dict: dict, right_dict: dict, key: Union[str, set, list]
+    ) -> None:
         """The static method to check if a key or a list/set of keys is available in both dictionaries.
 
         This method looks for a given key or list/set of keys in two dictionaries. Its main purpose is to assure that when comparing a key-value pair from two dictionaries, it actually exists in both.
@@ -151,13 +153,17 @@ class SnapshotCompare:
         elif isinstance(key, (set, list)):
             key_set = set(key)
         else:
-            raise WrongDataTypeException(f'The key variable is a {type(key)} but should be either: str, set or list')
+            raise WrongDataTypeException(
+                f"The key variable is a {type(key)} but should be either: str, set or list"
+            )
 
         left_snap_missing_key = False if key_set.issubset(left_dict.keys()) else True
         right_snap_missing_key = False if key_set.issubset(right_dict.keys()) else True
 
         if left_snap_missing_key and right_snap_missing_key:
-            raise MissingKeyException(f"{key} (some elements if set/list) is missing in both snapshots")
+            raise MissingKeyException(
+                f"{key} (some elements if set/list) is missing in both snapshots"
+            )
         if left_snap_missing_key or right_snap_missing_key:
             raise MissingKeyException(
                 f"{key} (some elements if set/list) is missing in {'left snapshot' if left_snap_missing_key else 'right snapshot'}"
@@ -703,10 +709,17 @@ class SnapshotCompare:
 
         requested_elements = set(next(iter(unary_dict)) for unary_dict in thresholds)
         try:
-            self.key_checker(self.left_snap[report_type], self.right_snap[report_type], requested_elements)
-        except MissingKeyException as exc:  # raised when any requested key is missing in one of the snapshots
+            self.key_checker(
+                self.left_snap[report_type],
+                self.right_snap[report_type],
+                requested_elements,
+            )
+        except (
+            MissingKeyException
+        ) as exc:  # raised when any requested key is missing in one of the snapshots
             raise SnapshotSchemeMismatchException(
-                f'Snapshots have missing keys in {requested_elements} for {report_type} report.') from exc
+                f"Snapshots have missing keys in {requested_elements} for {report_type} report."
+            ) from exc
 
         elements = ConfigParser(
             valid_elements=set(self.left_snap[report_type].keys()),

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -147,14 +147,14 @@ class SnapshotCompare:
         """
 
         if isinstance(key, str):
-            key_set = [key]
+            key_set = set([key])
         elif isinstance(key, (set, list)):
-            key_set = key
+            key_set = set(key)
         else:
             raise WrongDataTypeException(f'The key variable is a {type(key)} but should be either: str, set or list')
 
-        left_snap_missing_key = False if set(key_set).issubset(left_dict.keys()) else True
-        right_snap_missing_key = False if set(key_set).issubset(right_dict.keys()) else True
+        left_snap_missing_key = False if key_set.issubset(left_dict.keys()) else True
+        right_snap_missing_key = False if key_set.issubset(right_dict.keys()) else True
 
         if left_snap_missing_key and right_snap_missing_key:
             raise MissingKeyException(f"{key} (some elements if set/list) is missing in both snapshots")


### PR DESCRIPTION
## Description

Validates only the requested keys in `thresholds` parameter for `session_stats` comparison.
Includes an enhancement to SnapshotCompare `key_checker` method to check if a list/set is a subset of both sides.

## Motivation and Context

Currently, `session_stats` comparison expects all the keys to match between snapshots. This results in exception if PAN-OS API returns additional or fewer elements on the session info API call after upgrades. 
This PR checks only the requested keys (`thresholds`) to exist in both snapshots and ignores any other changes in the API response.
Fixes #47.

## How Has This Been Tested?

Tested with the snapshot_load_compare.py example script.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
