### PR TITLE
fix: locale setting need codeset to be set

### DIFF
--- a/docs/panos-upgrade-assurance/installation.mdx
+++ b/docs/panos-upgrade-assurance/installation.mdx
@@ -23,3 +23,7 @@ The **PAN-OS Upgrade Assurance** package is available in the [PyPI](https://pypi
 ``` console
 python -m pip install panos-upgrade-assurance
 ```
+
+## Requirements
+
+PAN-OS Upgrade Assurance package requires `en_US.UTF-8` locale to be present on the host running the library.

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -103,7 +103,7 @@ class CheckFirewall:
             CheckType.MP_DP_CLOCK_SYNC: self.check_mp_dp_sync,
         }
         locale.setlocale(
-            locale.LC_ALL, "en_US"
+            locale.LC_ALL, "en_US.UTF-8"
         )  # force locale for datetime string parsing when non-English locale is set on host
 
     def check_pending_changes(self) -> CheckResult:


### PR DESCRIPTION
## Description

Without the codeset information some hosts raise `locale.Error: unsupported locale setting` exception. 
This change sets `en_US.UTF-8` locale to be used.

## How Has This Been Tested?

Tested with example scripts on repo.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
