### PR TITLE
fix: mp clock parse without leading zero day

### DIFF
--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -977,7 +977,7 @@ class FirewallProxy(Firewall):
 
         """
         time_string = self.op_parser(cmd="show clock")
-        time_dict = time_string.split(" ")
+        time_dict = time_string.split()
         result = {
             "time": time_dict[3],
             "tz": time_dict[4],


### PR DESCRIPTION
## Description

Parse MP clock parsing for day without leading zero.

## Motivation and Context

Details can be found on the linked issue.
Fixes #62 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With example scripts on repo.

Before fix:
```
pan-os-upgrade-assurance % python examples/readiness_checks/run_readiness_checks.py -d x.x.x.x -u panadmin -p xxxxxx 
mp clock: Fri Jun  9 05:56:02 PDT 2023
Traceback (most recent call last):
  File "examples/readiness_checks/run_readiness_checks.py", line 105, in <module>
    check_readiness = check_node.run_readiness_checks(
  File "/Users/akose/Development/paloalto/pan-os-upgrade-assurance/panos_upgrade_assurance/check_firewall.py", line 781, in run_readiness_checks
    check_result = self._check_method_mapping[check_type](
  File "/Users/akose/Development/paloalto/pan-os-upgrade-assurance/panos_upgrade_assurance/check_firewall.py", line 680, in check_mp_dp_sync
    mp_dt = datetime.strptime(
  File "/Users/akose/.pyenv/versions/3.8.16/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/Users/akose/.pyenv/versions/3.8.16/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'PDT-Jun- 9' does not match format '%Y-%b-%d %H:%M:%S'
```

After fix:
```bash
pan-os-upgrade-assurance % python examples/readiness_checks/run_readiness_checks.py -d x.x.x.x -u panadmin -p xxxxx 
mp clock: Fri Jun  9 05:56:16 PDT 2023
 planes_clock_sync:
   | state: True
   | reason: [SUCCESS] 
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
