### PR TITLE
fix(FirewallProxy): wrong parsing for 2 Panorama hosts

### DIFF
--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -185,7 +185,7 @@ class FirewallProxy(Firewall):
         pan_status_list = pan_status.split("\n")
         pan_status_list_length = len(pan_status_list)
 
-        if pan_status_list_length in [3, 6]:
+        if pan_status_list_length in [3, 7]:
             for i in range(1, pan_status_list_length, 3):
                 pan_connected = interpret_yes_no(
                     (pan_status_list[i].split(":")[1]).strip()


### PR DESCRIPTION
## Description

Assumed wrong API response format for devices with more than 1 Panorama host configured.

## Motivation and Context

Panorama connectivity check throws an exception about malformed device response.

## How Has This Been Tested?

Run on hosts with different versions.

## Screenshots (if appropriate)



## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
