### PR TITLE
feat: ignore non-functional state in ha status and active checks

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -104,7 +104,9 @@ __Returns__
 ### `CheckFirewall.check_ha_status`
 
 ```python
-def check_ha_status(skip_config_sync: Optional[bool] = False) -> CheckResult
+def check_ha_status(
+        skip_config_sync: Optional[bool] = False,
+        ignore_non_functional: Optional[bool] = False) -> CheckResult
 ```
 
 Checks HA pair status from the perspective of the current device.
@@ -114,6 +116,7 @@ Currently, only Active-Passive configuration is supported.
 # Parameters:
 
 skip_config_sync (bool, optional): (defaults to `False`) Use with caution, when set to `True` will skip checking if configuration is synchronized between nodes. Helpful when verifying a state of a partially upgraded HA pair.
+ignore_non_functional (bool, optional): (defaults to `False`) Use with caution, when set to `True` will ignore if device state is "non-functional" on one of the nodes. Helpful when verifying a state of a partially upgraded HA pair with vmseries plugin version mismatch.
 
 # Returns
 
@@ -127,7 +130,8 @@ CheckResult: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/u
 
 ```python
 def check_is_ha_active(
-        skip_config_sync: Optional[bool] = False) -> CheckResult
+        skip_config_sync: Optional[bool] = False,
+        ignore_non_functional: Optional[bool] = False) -> CheckResult
 ```
 
 Checks whether this is an active node of an HA pair.
@@ -146,6 +150,7 @@ __Parameters__
 
 
 - __skip_config_sync__ (`bool, optional`): (defaults to `False`) Use with caution, when set to `True` will skip checking if configuration is synchronized between nodes. Helpful when working with a partially upgraded HA pair.
+- __ignore_non_functional__ (`bool, optional`): (defaults to `False`) Use with caution, when set to `True` will ignore if device state is "non-functional" on one of the nodes. Helpful when verifying a state of a partially upgraded HA pair with vmseries plugin version mismatch.
 
 __Returns__
 

--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -81,11 +81,11 @@ if __name__ == "__main__":
     checks = [
         "all",
         "panorama",
-        "ha",
         "ntp_sync",
         "candidate_config",
         "active_support",
         # checks below have optional configuration
+        {"ha": {"skip_config_sync": True, "ignore_non_functional": True}},
         {"content_version": {"version": "8635-7675"}},
         {"expired_licenses": {"skip_licenses": ["Threat Preventon"]}},
         {"planes_clock_sync": {"diff_threshold": 2}},
@@ -107,7 +107,8 @@ if __name__ == "__main__":
         # report_style=True
     )
     printer(check_readiness)
-    # node_state = check_node.check_is_ha_active(
-    #     # skip_config_sync=True
-    #     )
-    # print(bool(node_state), node_state)
+    node_state = check_node.check_is_ha_active(
+        skip_config_sync=True,
+        ignore_non_functional=True
+        )
+    print(bool(node_state), node_state)


### PR DESCRIPTION
## Description

When HA pair is partially upgraded HA status reports non-functional on the non-upgraded peer which results in failure to identify the active peer. This adds an option to ignore `non-functional` state in `check_ha_status` and `check_is_ha_active` checks.

## Motivation and Context

Makes it possible to identify active peer on HA pair with non-functional state.

## How Has This Been Tested?

Tested with example scripts on repo and Ansible playbooks.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
