### PR TITLE
fix: IPSec KeyError on ip_sec_tunnels snapshot

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -390,7 +390,7 @@ __Returns__
 ### `CheckFirewall.get_ip_sec_tunnels`
 
 ```python
-def get_ip_sec_tunnels() -> Dict[str, Union[str, int]]
+def get_ip_sec_tunnels() -> Dict[str, dict]
 ```
 
 Extract information about IPSEC tunnels from all tunnel data retrieved from a device.

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -710,7 +710,7 @@ class CheckFirewall:
         """
         return {"version": self._node.get_content_db_version()}
 
-    def get_ip_sec_tunnels(self) -> Dict[str, Union[str, int]]:
+    def get_ip_sec_tunnels(self) -> Dict[str, dict]:
         """Extract information about IPSEC tunnels from all tunnel data retrieved from a device.
 
         # Returns
@@ -735,7 +735,7 @@ class CheckFirewall:
         ```
 
         """
-        return self._node.get_tunnels()["IPSec"]
+        return self._node.get_tunnels().get("IPSec", {})
 
     def run_readiness_checks(
         self,


### PR DESCRIPTION
## Description

Get IPSec tunnel information with dict get method to avoid raising KeyError.

## Motivation and Context

See the attached issue for details.
Fixes #70 

## How Has This Been Tested?

Tested with example scripts on repo

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
