### PR TITLE
ci: add PAN.DEV pr creation

### DIFF
--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,0 +1,48 @@
+name: Close PR
+run-name: "Close Related PAN.DEV PR - (#${{ github.event.number }}) ${{ github.event.pull_request.title }}"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ['main']
+    types: ['closed']
+
+jobs:
+  close:
+    name: Close PAN.DEV preview PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          github-token: ${{ secrets.CLSC_PAT }}
+          script: |
+            let prs = await github.rest.pulls.list({
+              owner: "PaloAltoNetworks",
+              repo: "pan.dev",
+              state: "open",
+            })
+
+            let prs_list = prs.data
+
+            for (let pr of prs_list){
+              if (pr.head.label == "PaloAltoNetworks:${{ github.event.pull_request.head.ref }}"){
+                await github.rest.pulls.update({
+                  owner: "PaloAltoNetworks",
+                  repo: "pan.dev",
+                  pull_number: pr.number,
+                  state: "closed",
+                })
+                console.log("Closing related PAN.DEV PR: #" + pr.number + " - " + pr.title + " -> " + pr.url)
+                break
+              }
+            }

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -20,5 +20,5 @@ on:
 jobs:
   lint_pr_title:
     name: Lint PR
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@plan-apply
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v1
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,3 +50,5 @@ jobs:
     name: Create a preview PR for pan.dev
     uses: ./.github/workflows/sub_pandev.yml
     secrets: inherit
+    with:
+      head_branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,3 +55,4 @@ jobs:
     secrets: inherit
     with:
       head_branch: ${{ github.event.pull_request.head.ref }}
+      preview: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,30 +13,34 @@ on:
 
 jobs:
 
-  pyversion:
-    name: Discover minimum Python version
-    runs-on: ubuntu-latest
-    outputs:
-      pyversion: ${{ steps.pyversion.outputs.pyversion }}
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v3
-      - name: discover Python version
-        id: pyversion
-        uses: ./.github/actions/discover_python_version
+  # pyversion:
+  #   name: Discover minimum Python version
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     pyversion: ${{ steps.pyversion.outputs.pyversion }}
+  #   steps:
+  #     - name: checkout code
+  #       uses: actions/checkout@v3
+  #     - name: discover Python version
+  #       id: pyversion
+  #       uses: ./.github/actions/discover_python_version
 
-  code_format:
-    name: Formatting and security
-    needs: [pyversion]
-    uses: ./.github/workflows/sub_format.yml
-    with:
-      python_version: ${{ needs.pyversion.outputs.pyversion }}
-      poetry_version: 1.4.2
+  # code_format:
+  #   name: Formatting and security
+  #   needs: [pyversion]
+  #   uses: ./.github/workflows/sub_format.yml
+  #   with:
+  #     python_version: ${{ needs.pyversion.outputs.pyversion }}
+  #     poetry_version: 1.4.2
 
-  documentation_check:
-    name: API documentation
-    needs: [pyversion]
-    uses: ./.github/workflows/sub_docs.yml
-    with:
-      python_version: ${{ needs.pyversion.outputs.pyversion }}
-      poetry_version: 1.4.2
+  # documentation_check:
+  #   name: API documentation
+  #   needs: [pyversion]
+  #   uses: ./.github/workflows/sub_docs.yml
+  #   with:
+  #     python_version: ${{ needs.pyversion.outputs.pyversion }}
+  #     poetry_version: 1.4.2
+
+  update_pandev:
+    name: Create a preview PR for pan.dev
+    uses: ./.github/workflows/sub_pandev.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,36 +18,39 @@ permissions:
 
 jobs:
 
-  # pyversion:
-  #   name: Discover minimum Python version
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     pyversion: ${{ steps.pyversion.outputs.pyversion }}
-  #   steps:
-  #     - name: checkout code
-  #       uses: actions/checkout@v3
-  #     - name: discover Python version
-  #       id: pyversion
-  #       uses: ./.github/actions/discover_python_version
+  pyversion:
+    name: Discover minimum Python version
+    runs-on: ubuntu-latest
+    outputs:
+      pyversion: ${{ steps.pyversion.outputs.pyversion }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: discover Python version
+        id: pyversion
+        uses: ./.github/actions/discover_python_version
 
-  # code_format:
-  #   name: Formatting and security
-  #   needs: [pyversion]
-  #   uses: ./.github/workflows/sub_format.yml
-  #   with:
-  #     python_version: ${{ needs.pyversion.outputs.pyversion }}
-  #     poetry_version: 1.4.2
+  code_format:
+    name: Formatting and security
+    needs: [pyversion]
+    uses: ./.github/workflows/sub_format.yml
+    with:
+      python_version: ${{ needs.pyversion.outputs.pyversion }}
+      poetry_version: 1.4.2
 
-  # documentation_check:
-  #   name: API documentation
-  #   needs: [pyversion]
-  #   uses: ./.github/workflows/sub_docs.yml
-  #   with:
-  #     python_version: ${{ needs.pyversion.outputs.pyversion }}
-  #     poetry_version: 1.4.2
+  documentation_check:
+    name: API documentation
+    needs: [pyversion]
+    uses: ./.github/workflows/sub_docs.yml
+    with:
+      python_version: ${{ needs.pyversion.outputs.pyversion }}
+      poetry_version: 1.4.2
 
   update_pandev:
     name: Create a preview PR for pan.dev
+    needs:
+      - code_format
+      - documentation_check
     uses: ./.github/workflows/sub_pandev.yml
     secrets: inherit
     with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,9 +12,7 @@ on:
     branches: ['main']
 
 permissions:
-  contents: write
-  pull-requests: write
-
+  contents: read
 
 jobs:
 
@@ -46,13 +44,83 @@ jobs:
       python_version: ${{ needs.pyversion.outputs.pyversion }}
       poetry_version: 1.4.2
 
-  update_pandev:
-    name: Create a preview PR for pan.dev
+  store_documentation:
+    name: Fetch the updated documentation
     needs:
       - code_format
       - documentation_check
-    uses: ./.github/workflows/sub_pandev.yml
-    secrets: inherit
-    with:
-      head_branch: ${{ github.event.pull_request.head.ref }}
-      preview: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: pack the documentation
+        working-directory: docs
+        run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
+      - name: upload the documentation artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: docs/documentation.tar
+
+  pandev_pr:
+    name: Create a preview PR for pan.dev
+    needs: store_documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout pan.dev fork
+        uses: actions/checkout@v3
+        with:
+          repository: PaloAltoNetworks/pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+
+      - name: download documentation artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: documentation
+          path: products/panos/docs
+
+      - name: unpack the documentation
+        working-directory: products/panos/docs
+        run: |
+          rm -rf 'panos-upgrade-assurance'
+          tar xvf documentation.tar
+          rm -f documentation.tar
+
+      - name: create a PR to upstream pan.dev
+        id: pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+          delete-branch: true
+          branch: "${{ github.event.pull_request.head.ref }}"
+          title: "[PAN-OS Upgrade Assurance][${{ github.event.pull_request.head.ref }}] documentation PREVIEW - do NOT MERGE"
+          commit-message: "docs: PanOS Upgrade Assurance documentation update"
+          body: |
+            # Description
+            
+            DO NOT MERGE - preview PR made for changes on branch: ${{ github.event.pull_request.head.ref }}.
+
+            # Types of changes
+
+            New feature (non-breaking change which adds functionality)
+
+      - name: find if we have a comment
+        uses: peter-evans/find-comment@v2
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: A Preview PR in PanDev repo has been created
+          repository: ${{ github.repository }}
+
+      - name: comment back on the original PR
+        if: steps.find.outputs.comment-id == '' &&  steps.pr.outputs.pull-request-url != ''
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          body: |
+            A Preview PR in PanDev repo has been created. You can view it [here](${{ steps.pr.outputs.pull-request-url }}).

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,11 @@ on:
       - ready_for_review
     branches: ['main']
 
+permissions:
+  contents: write
+  pull-requests: write
+
+
 jobs:
 
   # pyversion:
@@ -44,3 +49,4 @@ jobs:
   update_pandev:
     name: Create a preview PR for pan.dev
     uses: ./.github/workflows/sub_pandev.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
   release:
     name: Create a new release
     runs-on: ubuntu-latest
+    if: needs.rc.outputs.rc == 'true'
     needs:
       - rc
       - code_format
@@ -77,7 +78,9 @@ jobs:
     permissions:
       contents: write
       issues: read
-    if: needs.rc.outputs.rc == 'true'
+    outputs:
+      released: ${{ steps.release.outputs.new_release_published }}
+      tag: ${{ steps.release.outputs.new_release_git_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -113,3 +116,57 @@ jobs:
             @semantic-release/git@^10.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup_pandev:
+    name: Cleanup documentation release PRs @PAN.DEV
+    runs-on: ubuntu-latest
+    if: needs.release.outputs.release == 'true'
+    needs: release
+    permissions:
+      pull_request: write
+    steps:
+      - name: cleanup old PRs
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          github-token: ${{ secrets.CLSC_PAT }}
+          script: |
+            let prs = await github.rest.pulls.list({
+              owner: "PaloAltoNetworks",
+              repo: "pan.dev",
+              state: "open",
+            })
+
+            let prs_list = prs.data
+            console.log("Total PRs found: " + prs_list.length)
+
+            let found = false
+            let pr_no
+
+            if (prs_list.length > 0){
+              console.log("Removing obsolete PRs:")
+              for (let pr of prs_list){
+                if (pr.head.label.includes("PaloAltoNetworks:v")){
+                  console.log(" - removing PR (#" + pr.number + ") " + pr.title + " -> " + pr.url)
+
+                  await github.rest.pulls.update({
+                    owner: "PaloAltoNetworks",
+                    repo: "pan.dev",
+                    pull_number: pr.number,
+                    state: "closed",
+                  })
+                }
+              }
+            }
+
+  update_pandev:
+    name: Create a PR for pan.dev
+    if: needs.release.outputs.release == 'true'
+    needs: 
+      - cleanup_pandev
+      - release
+    uses: ./.github/workflows/sub_pandev.yml
+    secrets: inherit
+    with:
+      head_branch: ${{ needs.release.outputs.tag }}
+      preview: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
   cleanup_pandev:
     name: Cleanup documentation release PRs @PAN.DEV
     runs-on: ubuntu-latest
-    if: needs.release.outputs.release == 'true'
+    if: needs.release.outputs.released == 'true'
     needs: release
     permissions:
       pull_request: write
@@ -146,7 +146,10 @@ jobs:
             if (prs_list.length > 0){
               console.log("Removing obsolete PRs:")
               for (let pr of prs_list){
-                if (pr.head.label.includes("PaloAltoNetworks:v")){
+                if (
+                  pr.head.label.includes("PaloAltoNetworks:v")
+                  && pr.head.repo.full_name == "PaloAltoNetworks/panos-upgrade-assurance-pan.dev"
+                ){
                   console.log(" - removing PR (#" + pr.number + ") " + pr.title + " -> " + pr.url)
 
                   await github.rest.pulls.update({
@@ -159,14 +162,69 @@ jobs:
               }
             }
 
+  store_documentation:
+    name: Fetch the updated documentation
+    if: needs.release.outputs.released == 'true'
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: pack the documentation
+        working-directory: docs
+        run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
+      - name: upload the documentation artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: docs/documentation.tar
+
   update_pandev:
     name: Create a PR for pan.dev
-    if: needs.release.outputs.release == 'true'
+    if: needs.release.outputs.released == 'true'
     needs: 
       - cleanup_pandev
       - release
-    uses: ./.github/workflows/sub_pandev.yml
-    secrets: inherit
-    with:
-      head_branch: ${{ needs.release.outputs.tag }}
-      preview: false
+      - store_documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout pan.dev fork
+        uses: actions/checkout@v3
+        with:
+          repository: PaloAltoNetworks/pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+
+      - name: download documentation artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: documentation
+          path: products/panos/docs
+
+      - name: unpack the documentation
+        working-directory: products/panos/docs
+        run: |
+          rm -rf 'panos-upgrade-assurance'
+          tar xvf documentation.tar
+          rm -f documentation.tar
+
+      - name: create a PR to upstream pan.dev
+        id: pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+          delete-branch: true
+          branch: "${{ needs.release.outputs.tag }}"
+          title: "[PAN-OS Upgrade Assurance] documentation update for release: ${{ needs.release.outputs.tag }}"
+          commit-message: "docs: PanOS Upgrade Assurance documentation update"
+          body: |
+            # Description
+            
+            A PR made for changes introduced into documentation on ${{ needs.release.outputs.tag }} release.
+
+            # Types of changes
+
+            New feature (non-breaking change which adds functionality)

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -34,58 +34,59 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: checkout pan.dev fork
-        uses: actions/checkout@v3
-        with:
-          repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
-          token: ${{ secrets.CLSC_PAT }}
-          # fetch: 0
+      # - name: checkout pan.dev fork
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+      #     token: ${{ secrets.CLSC_PAT }}
+      #     # fetch: 0
 
-      - name: checkout a branch and do some modifications
-        id: branch
-        run: |
-          set -x
+      # - name: checkout a branch and do some modifications
+      #   id: branch
+      #   run: |
+      #     set -x
 
-          git config --global user.email "FoSix@users.noreply.github.com"
-          git config --global user.name FoSix
+      #     git config --global user.email "FoSix@users.noreply.github.com"
+      #     git config --global user.name FoSix
 
-          git remote add upstream https://github.com/PaloAltoNetworks/pan.dev.git
-          git fetch origin
-          git fetch upstream
-          git merge upstream/master
-          git push origin
+      #     git remote add upstream https://github.com/PaloAltoNetworks/pan.dev.git
+      #     git fetch origin
+      #     git fetch upstream
+      #     git merge upstream/master
+      #     git push origin
 
-          if [ "$(git branch  -r --list 'origin/upgrade-assurance-documentation-update')" ]; then
-            git checkout upgrade-assurance-documentation-update
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            git branch upgrade-assurance-documentation-update
-            git checkout upgrade-assurance-documentation-update
-            git push -u origin upgrade-assurance-documentation-update
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+      #     if [ "$(git branch  -r --list 'origin/upgrade-assurance-documentation-update')" ]; then
+      #       git checkout upgrade-assurance-documentation-update
+      #       echo "exists=true" >> $GITHUB_OUTPUT
+      #     else
+      #       git branch upgrade-assurance-documentation-update
+      #       git checkout upgrade-assurance-documentation-update
+      #       git push -u origin upgrade-assurance-documentation-update
+      #       echo "exists=false" >> $GITHUB_OUTPUT
+      #     fi
 
-          git merge master
-          date >> file
-          git add file
-          git commit -m 'modyfing brach for PR'
-          git push
+      #     git merge master
+      #     date >> file
+      #     git add file
+      #     git commit -m 'modyfing brach for PR'
+      #     git push
 
       - name: create a PR from fork
         uses: actions/github-script@v6
-        if: steps.branch.outputs.exists == 'false'
+        # if: steps.branch.outputs.exists == 'false'
         with:
           github-token: ${{ secrets.CLSC_PAT }}
           script: |
             octokit.rest.pulls.create({
               owner: context.repo.owner,
-              repo: "PaloAltoNetworks/pan.dev"
-              base: "master",
-              head_repo: "PaloAltoNetworks/panos-upgrade-assurance-pan.dev"
-              head: "PaloAltoNetworks:upgrade-assurance-documentation-update",
-              body: "PREVIEW - DO NOT MERGE",
-              title: "PREVIEW - DO NOT MERGE",
+              repo: 'PaloAltoNetworks/pan.dev'
+              base: 'master',
+              head_repo: 'PaloAltoNetworks/panos-upgrade-assurance-pan.dev',
+              head: 'PaloAltoNetworks:upgrade-assurance-documentation-update',
+              body: 'PREVIEW - DO NOT MERGE',
+              title: 'PREVIEW - DO NOT MERGE'
             });
+          debug: true
 
 
 

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -11,24 +11,24 @@ on:
   workflow_call:
 
 jobs:
-  fetch:
-    name: Fetch the updated documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v3
-      - name: pack the documentation
-        working-directory: docs
-        run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
-      - name: upload the documentation artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation
-          path: docs/documentation.tar
+  # fetch:
+  #   name: Fetch the updated documentation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout code
+  #       uses: actions/checkout@v3
+  #     - name: pack the documentation
+  #       working-directory: docs
+  #       run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
+  #     - name: upload the documentation artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: documentation
+  #         path: docs/documentation.tar
 
   update:
     name: Prepare a PR for pan.dev
-    needs: [fetch]
+    # needs: [fetch]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -37,24 +37,76 @@ jobs:
       - name: checkout pan.dev fork
         uses: actions/checkout@v3
         with:
-          repository: PaloAltoNetworks/pan.dev
+          repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
           token: ${{ secrets.CLSC_PAT }}
-      - name: download documentation artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: documentation
-          path: products/panos/docs
-      - name: unpack the documentation
-        working-directory: products/panos/docs
+          # fetch: 0
+
+      - name: checkout a branch and do some modifications
+        id: branch
         run: |
-          rm -rf 'panos-upgrade-assurance'
-          tar xvf documentation.tar
-          rm -f documentation.tar
-      - name: create a PR to upstram pan.dev
-        uses: peter-evans/create-pull-request@v5
+          set -x
+
+          git config --global user.email "FoSix@users.noreply.github.com"
+          git config --global user.name FoSix
+
+          git remote add upstream https://github.com/PaloAltoNetworks/pan.dev.git
+          git fetch origin
+          git fetch upstream
+          git merge upstream/master
+          git push origin
+
+          if [ "$(git branch  -r --list 'origin/upgrade-assurance-documentation-update')" ]; then
+            git checkout upgrade-assurance-documentation-update
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            git branch upgrade-assurance-documentation-update
+            git checkout upgrade-assurance-documentation-update
+            git push -u origin upgrade-assurance-documentation-update
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+          git merge master
+          date >> file
+          git add file
+          git commit -m 'modyfing brach for PR'
+          git push
+
+      - name: create a PR from fork
+        uses: actions/github-script@v6
+        if: steps.branch.outputs.exists == 'false'
         with:
-          push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
-          token: ${{ secrets.CLSC_PAT }}
+          github-token: ${{ secrets.CLSC_PAT }}
+          script: |
+            octokit.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: "PaloAltoNetworks/pan.dev"
+              base: "master",
+              head_repo: "PaloAltoNetworks/panos-upgrade-assurance-pan.dev"
+              head: "PaloAltoNetworks:upgrade-assurance-documentation-update",
+              body: "PREVIEW - DO NOT MERGE",
+              title: "PREVIEW - DO NOT MERGE",
+            });
+
+
+
+
+
+      # - name: download documentation artifact
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: documentation
+      #     path: products/panos/docs
+      # - name: unpack the documentation
+      #   working-directory: products/panos/docs
+      #   run: |
+      #     rm -rf 'panos-upgrade-assurance'
+      #     tar xvf documentation.tar
+      #     rm -f documentation.tar
+      # - name: create a PR to upstram pan.dev
+      #   uses: peter-evans/create-pull-request@v5
+      #   with:
+      #     push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+      #     token: ${{ secrets.CLSC_PAT }}
           # delete-branch: true
           # branch: PaloAltoNetworks/panos-upgrade-assurance-pan.dev:upgrade-assurance-documentation-update
           # title: "[PAN-OS Upgrade Assurance] documentation PREVIEW - do NOT MERGE"

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -14,11 +14,14 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      - name: cache documentation
-        uses: actions/cache@v3
+      - name: pack the documentation
+        working-directory: docs
+        run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
+      - name: upload the documentation artifact
+        uses: actions/upload-artifact@v3
         with:
-          path: docs
-          key: ${{ github.sha }}
+          name: documentation
+          path: docs/documentation.tar
 
   update:
     name: Prepare a PR for pan.dev
@@ -29,9 +32,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
-      - name: load the updated documentation from cache
-        uses: actions/cache@v3
+      - name: download documentation artifact
+        uses: actions/download-artifact@v3
         with:
-          path: docs
-          key: ${{ github.sha }}
-      - run: ls -ltr docs
+          name: documentation
+          path: products/panos/docs
+      - name: unpack the documentation
+        working-directory: products/panos/docs
+        run: |
+          rm -rf 'panos-upgrade-assurance'
+          tar xvf documentation.tar
+          rm -f documentation.tar
+          ls -ltr
+          ls -ltr 'panos-upgrade-assurance'

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -14,6 +14,10 @@ on:
         description: Name of a branch from which the PR in source repository is created
         type: string
         required: true
+      preview:
+        description: Flag that indicates if the PR in PAN.DEV should be a preview PR or a release PR
+        type: boolean
+        required: true
 
 jobs:
   fetch:
@@ -44,32 +48,58 @@ jobs:
         with:
           repository: PaloAltoNetworks/pan.dev
           token: ${{ secrets.CLSC_PAT }}
-          # fetch: 0
+
       - name: download documentation artifact
         uses: actions/download-artifact@v3
         with:
           name: documentation
           path: products/panos/docs
+
       - name: unpack the documentation
         working-directory: products/panos/docs
         run: |
           rm -rf 'panos-upgrade-assurance'
           tar xvf documentation.tar
           rm -f documentation.tar
+
+      - name: prepare title and body strings
+        id: pr_data
+        env:
+          PREVIEW: ${{ inputs.preview }}
+          BRANCH: ${{ inputs.head_branch }}
+        run: |
+          if [ "$PREVIEW" == "true" ]; then
+            echo "pr_title=[PAN-OS Upgrade Assurance][${BRANCH}] documentation PREVIEW - do NOT MERGE" >> $GITHUB_OUTPUT
+            echo "pr_body=DO NOT MERGE - preview PR made for changes on branch: ${$BRANCH}." >> $GITHUB_OUTPUT
+          else
+            echo "pr_title=[PAN-OS Upgrade Assurance] documentation update for release: ${BRANCH}" >> $GITHUB_OUTPUT
+            echo "pr_body=A PR made for changes introduced into documentation on ${BRANCH} release." >> $GITHUB_OUTPUT
+          fi
+
       - name: create a PR to upstream pan.dev
-        uses: peter-evans/create-pull-request@head-repo
+        id: pr
+        uses: peter-evans/create-pull-request@v5
         with:
           push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
           token: ${{ secrets.CLSC_PAT }}
           delete-branch: true
           branch: "${{ inputs.head_branch }}"
-          title: "[PAN-OS Upgrade Assurance][${{ inputs.head_branch }}] documentation PREVIEW - do NOT MERGE"
-          commit-message: "docs: documentation update"
+          title: ${{ steps.pr_data.outputs.pr_title }} 
+          commit-message: "docs: PanOS Upgrade Assurance documentation update"
           body: |
             # Description
             
-            DO NOT MERGE - preview PR made for changes on branch: ${{ inputs.head_branch }}.
+            ${{ steps.pr_data.outputs.pr_body }}
 
             # Types of changes
 
             New feature (non-breaking change which adds functionality)
+
+      - name: comment back on the original PR
+        if: steps.pr.outputs.pull-request-url != '' && github.event.action == 'opened' && inputs.preview == 'true'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          body: |
+            A Preview PR in PanDev repo has been created. You can view it [here](${{ steps.pr.outputs.pull-request-url }}).

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -14,9 +14,24 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v3
-      - run: ls -l
-      # - name: cache documentation
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: 
-      #     key: ${{ github.sha }}
+      - name: cache documentation
+        uses: actions/cache@v3
+        with:
+          path: docs
+          key: ${{ github.sha }}
+
+  update:
+    name: Prepare a PR for pan.dev
+    needs: [fetch]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout pan.dev fork
+        uses: actions/checkout@v3
+        with:
+          repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+      - name: load the updated documentation from cache
+        uses: actions/cache@v3
+        with:
+          path: docs
+          key: ${{ github.sha }}
+      - run: ls -ltr docs

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -9,114 +9,67 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      head_branch:
+        description: Name of a branch from which the PR in source repository is created
+        type: string
+        required: true
 
 jobs:
-  # fetch:
-  #   name: Fetch the updated documentation
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout code
-  #       uses: actions/checkout@v3
-  #     - name: pack the documentation
-  #       working-directory: docs
-  #       run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
-  #     - name: upload the documentation artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: documentation
-  #         path: docs/documentation.tar
+  fetch:
+    name: Fetch the updated documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: pack the documentation
+        working-directory: docs
+        run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
+      - name: upload the documentation artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: docs/documentation.tar
 
   update:
     name: Prepare a PR for pan.dev
-    # needs: [fetch]
+    needs: [fetch]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      # - name: checkout pan.dev fork
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
-      #     token: ${{ secrets.CLSC_PAT }}
-      #     # fetch: 0
-
-      # - name: checkout a branch and do some modifications
-      #   id: branch
-      #   run: |
-      #     set -x
-
-      #     git config --global user.email "FoSix@users.noreply.github.com"
-      #     git config --global user.name FoSix
-
-      #     git remote add upstream https://github.com/PaloAltoNetworks/pan.dev.git
-      #     git fetch origin
-      #     git fetch upstream
-      #     git merge upstream/master
-      #     git push origin
-
-      #     if [ "$(git branch  -r --list 'origin/upgrade-assurance-documentation-update')" ]; then
-      #       git checkout upgrade-assurance-documentation-update
-      #       echo "exists=true" >> $GITHUB_OUTPUT
-      #     else
-      #       git branch upgrade-assurance-documentation-update
-      #       git checkout upgrade-assurance-documentation-update
-      #       git push -u origin upgrade-assurance-documentation-update
-      #       echo "exists=false" >> $GITHUB_OUTPUT
-      #     fi
-
-      #     git merge master
-      #     date >> file
-      #     git add file
-      #     git commit -m 'modyfing brach for PR'
-      #     git push
-
-      - name: create a PR from fork
-        uses: actions/github-script@v6
-        # if: steps.branch.outputs.exists == 'false'
+      - name: checkout pan.dev fork
+        uses: actions/checkout@v3
         with:
-          github-token: ${{ secrets.CLSC_PAT }}
-          script: |
-            octokit.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: 'PaloAltoNetworks/pan.dev'
-              base: 'master',
-              head_repo: 'PaloAltoNetworks/panos-upgrade-assurance-pan.dev',
-              head: 'PaloAltoNetworks:upgrade-assurance-documentation-update',
-              body: 'PREVIEW - DO NOT MERGE',
-              title: 'PREVIEW - DO NOT MERGE'
-            });
-          debug: true
-
-
-
-
-
-      # - name: download documentation artifact
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: documentation
-      #     path: products/panos/docs
-      # - name: unpack the documentation
-      #   working-directory: products/panos/docs
-      #   run: |
-      #     rm -rf 'panos-upgrade-assurance'
-      #     tar xvf documentation.tar
-      #     rm -f documentation.tar
-      # - name: create a PR to upstram pan.dev
-      #   uses: peter-evans/create-pull-request@v5
-      #   with:
-      #     push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
-      #     token: ${{ secrets.CLSC_PAT }}
-          # delete-branch: true
-          # branch: PaloAltoNetworks/panos-upgrade-assurance-pan.dev:upgrade-assurance-documentation-update
-          # title: "[PAN-OS Upgrade Assurance] documentation PREVIEW - do NOT MERGE"
-          # commit-message: "docs: documentation update"
-          # body: |
-          #   # Description
+          repository: PaloAltoNetworks/pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+          # fetch: 0
+      - name: download documentation artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: documentation
+          path: products/panos/docs
+      - name: unpack the documentation
+        working-directory: products/panos/docs
+        run: |
+          rm -rf 'panos-upgrade-assurance'
+          tar xvf documentation.tar
+          rm -f documentation.tar
+      - name: create a PR to upstream pan.dev
+        uses: peter-evans/create-pull-request@head-repo
+        with:
+          push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+          delete-branch: true
+          branch: "${{ inputs.head_branch }}"
+          title: "[PAN-OS Upgrade Assurance][${{ inputs.head_branch }}] documentation PREVIEW - do NOT MERGE"
+          commit-message: "docs: documentation update"
+          body: |
+            # Description
             
-          #   DO NOT MERGE - preview PR
+            DO NOT MERGE - preview PR made for changes on branch: ${{ inputs.head_branch }}.
 
-          #   # Types of changes
+            # Types of changes
 
-          #   New feature (non-breaking change which adds functionality)
+            New feature (non-breaking change which adds functionality)

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -1,0 +1,22 @@
+name: (sub) Code Format and Security
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+
+jobs:
+  fetch:
+    name: Fetch the updated documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - run: ls -l
+      # - name: cache documentation
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: 
+      #     key: ${{ github.sha }}

--- a/.github/workflows/sub_pandev.yml
+++ b/.github/workflows/sub_pandev.yml
@@ -4,6 +4,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
 
@@ -27,11 +30,15 @@ jobs:
     name: Prepare a PR for pan.dev
     needs: [fetch]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: checkout pan.dev fork
         uses: actions/checkout@v3
         with:
-          repository: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+          repository: PaloAltoNetworks/pan.dev
+          token: ${{ secrets.CLSC_PAT }}
       - name: download documentation artifact
         uses: actions/download-artifact@v3
         with:
@@ -43,5 +50,20 @@ jobs:
           rm -rf 'panos-upgrade-assurance'
           tar xvf documentation.tar
           rm -f documentation.tar
-          ls -ltr
-          ls -ltr 'panos-upgrade-assurance'
+      - name: create a PR to upstram pan.dev
+        uses: peter-evans/create-pull-request@v5
+        with:
+          push-to-fork: PaloAltoNetworks/panos-upgrade-assurance-pan.dev
+          token: ${{ secrets.CLSC_PAT }}
+          # delete-branch: true
+          # branch: PaloAltoNetworks/panos-upgrade-assurance-pan.dev:upgrade-assurance-documentation-update
+          # title: "[PAN-OS Upgrade Assurance] documentation PREVIEW - do NOT MERGE"
+          # commit-message: "docs: documentation update"
+          # body: |
+          #   # Description
+            
+          #   DO NOT MERGE - preview PR
+
+          #   # Types of changes
+
+          #   New feature (non-breaking change which adds functionality)


### PR DESCRIPTION
## Description

Adds an automatic PR into PAN.DEV repository with updated documentation.

## Motivation and Context

Each release might require official documentation updates. A nice-to-have is a PREVIEW PR with documentation that will get merged to `main`.

This PR will introduce:

- A *PREVIEW* PR to PAN.DEV for each PR created in this repository
- A PR to PAN.DEV for each release published in this repository
- If a PR get's merged or closed the *PREVIEW* PR will be automatically closed
- If a new release is published before the PR in PAN.DEV gets merged, the pending PR (all of them) will be closed and a new one with current documentation will be created. 

## How Has This Been Tested?

All workflows tested on a separate repository

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
