### PR TITLE
fix: snapshot comparison with no common keys

### DIFF
--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -384,8 +384,8 @@ class SnapshotCompare:
 
         """
 
-        if not (left_side_to_compare and right_side_to_compare):
-            return {}
+        # if not (left_side_to_compare and right_side_to_compare):
+        #     return {}
 
         result = dict(
             missing=dict(passed=True, missing_keys=[]),
@@ -406,8 +406,8 @@ class SnapshotCompare:
                 result["added"]["added_keys"].append(key)
 
         common_keys = left_side_to_compare.keys() & right_side_to_compare.keys()
-        at_lowest_level = True if isinstance(next(iter(right_side_to_compare.values())), str) else False
         if common_keys:
+            at_lowest_level = True if isinstance(left_side_to_compare[next(iter(common_keys))], str) else False
             keys_to_check = (
                 ConfigParser(valid_elements=set(common_keys), requested_config=properties).prepare_config()
                 if at_lowest_level

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -404,7 +404,7 @@ class SnapshotCompare:
         common_keys = left_side_to_compare.keys() & right_side_to_compare.keys()
         if common_keys:
             next_level_value = left_side_to_compare[next(iter(common_keys))]
-            at_lowest_level = True if isinstance(next_level_value, (str, type(None))) else False
+            at_lowest_level = True if not isinstance(next_level_value, dict) else False
             keys_to_check = (
                 ConfigParser(valid_elements=set(common_keys), requested_config=properties).prepare_config()
                 if at_lowest_level


### PR DESCRIPTION
## Description

This change avoids an unhandled exception when no common keys exist in snapshot comparison and generate an output with added/missing keys.

Also fixes #82 where snapshot comparison properties are getting ignored occasionally. 

## Motivation and Context

In snapshot comparison when snapshots to be compared had no common keys, this resulted in an un-handled lndexError exception given below. This was happening mostly on arp table comparison where two snapshots had no common entries. 

```python
Traceback (most recent call last):
  File "snapshot_load_compare.py", line 39, in <module>
    report = compare.compare_snapshots(reports)
  File "/Users/akose/Development/paloalto/pan-os-upgrade-assurance/panos_upgrade_assurance/snapshot_compare.py", line 126, in compare_snapshots
    {report_type: self._functions_mapping[report_type](**report_config)}
  File "/Users/akose/Development/paloalto/pan-os-upgrade-assurance/panos_upgrade_assurance/snapshot_compare.py", line 565, in get_diff_and_threshold
    diff = SnapshotCompare.calculate_diff_on_dicts(
  File "/Users/akose/Development/paloalto/pan-os-upgrade-assurance/panos_upgrade_assurance/snapshot_compare.py", line 400, in calculate_diff_on_dicts
    if isinstance(right_side_to_compare[list(common_keys)[0]], str)
IndexError: list index out of range
```

Regarding issue #82 - the check was to compare with string type to find out if we are at the lowest level, and when we encountered a null/None value ConfigParser was not called which resulted in properties not getting processed. This happened randomly since we are checking a value within the common keys and null/None value might or might not be present for the selected key.

## How Has This Been Tested?

It has been tested with example scripts in the repository and ansible playbooks.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
