### PR TITLE
feat: add option to skip locale enforcement

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -48,7 +48,8 @@ __Attributes__
 ### `CheckFirewall.__init__`
 
 ```python
-def __init__(node: FirewallProxy) -> None
+def __init__(node: FirewallProxy,
+             skip_force_locale: Optional[bool] = False) -> None
 ```
 
 CheckFirewall constructor.
@@ -58,6 +59,8 @@ __Parameters__
 
 - __node__ (`FirewallProxy`): Object representing a device against which checks and/or snapshots are run. See
     [`FirewallProxy`](/panos/docs/panos-upgrade-assurance/api/firewall_proxy#class-firewallproxy) class' documentation.
+- __skip_force_locale__ (`bool, optional`): (defaults to `False`) Use with caution, when set to `True` will skip setting locale to
+    en_US.UTF-8 for the module which will parse the datetime strings in checks with current locale setting.
 
 ### `CheckFirewall.check_pending_changes`
 

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -58,13 +58,15 @@ class CheckFirewall:
 
     """
 
-    def __init__(self, node: FirewallProxy) -> None:
+    def __init__(self, node: FirewallProxy, skip_force_locale: Optional[bool] = False) -> None:
         """CheckFirewall constructor.
 
         # Parameters
 
         node (FirewallProxy): Object representing a device against which checks and/or snapshots are run. See
             [`FirewallProxy`](/panos/docs/panos-upgrade-assurance/api/firewall_proxy#class-firewallproxy) class' documentation.
+        skip_force_locale (bool, optional): (defaults to `False`) Use with caution, when set to `True` will skip setting locale to
+            en_US.UTF-8 for the module which will parse the datetime strings in checks with current locale setting.
 
         """
         self._node = node
@@ -93,9 +95,10 @@ class CheckFirewall:
             CheckType.MP_DP_CLOCK_SYNC: self.check_mp_dp_sync,
             CheckType.CERTS: self.check_ssl_cert_requirements,
         }
-        locale.setlocale(
-            locale.LC_ALL, "en_US.UTF-8"
-        )  # force locale for datetime string parsing when non-English locale is set on host
+        if not skip_force_locale:
+            locale.setlocale(
+                locale.LC_ALL, "en_US.UTF-8"
+            )  # force locale for datetime string parsing when non-English locale is set on host
 
     def check_pending_changes(self) -> CheckResult:
         """Check if there are pending changes on device.


### PR DESCRIPTION
## Description

Adds a flag to CheckFirewall to skip locale enforcement to en_US.UTF-8 which will run with the default locale settings on the host running the library. 

## Motivation and Context

Fixes #81 

## How Has This Been Tested?

Tested with local example script and ansible playbook.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
