### PR TITLE
fix: snapshot comparison on dicts with different levels

### DIFF
--- a/examples/report/snapshot_load_compare.py
+++ b/examples/report/snapshot_load_compare.py
@@ -20,6 +20,37 @@ if __name__ == "__main__":
         {"arp_table": {"properties": ["!ttl"], "count_change_threshold": 10}},
         {"nics": {"count_change_threshold": 10}},
         {"license": {"properties": ["!serial"]}},
+
+        # {"license": {
+        #     "properties": ["!serial", "!issued", "!authcode", "!expires", "!custom", "non-existing"] # exclude higher level
+        # }},
+        # {"license": {
+        #     "properties": ["!serial", "!issued", "!authcode", "!expires", "non-existing", "!_Log_Storage_TB"] # works in multi-levels
+        # }},
+        # {"license": {
+        #     "properties": ["all"]
+        # }},
+        # {"license": {
+        #     "properties": ["!serial", "!issued", "!authcode", "!expires", "non-existing"] # invalid config is ignored and all is appended if all other are valid exclusions..
+        # }},
+        # {"license": {
+        #     "properties": ["serial", "non-existing"] # compare only requested
+        # }},
+        # {"license": {
+        #     "properties": ["!issued", "all"] # compare all except
+        # }},
+        # {"license": {
+        #     "properties": ["!issued", "serial"] # skip one and compare specific ones
+        # }},
+        # {"license": {
+        #     "properties": ["Logging Service"]  # even works for parent level
+        # }},
+        # {"license": {
+        #     "properties": ["Logging Service", "!custom"]  # combination with parent
+        # }},
+        # "!license",
+        # "license",
+
         {"routes": {"properties": ["!flags"], "count_change_threshold": 10}},
         "!content_version",
         {

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -235,10 +235,10 @@ class SnapshotCompare:
     ) -> Dict[str, dict]:
         """The static method to calculate a difference between two dictionaries.
 
-        By default dictionaries are compared by going down all nested levels, to the point where key-value pairs are just strings
-        or numbers. It is possible to configure which keys from these pairs should be compared (by default we compare all
-        available keys). This is done using the `properties` parameter. It's a list of the bottom most level keys. For example,
-        when comparing route tables snapshots are formatted like:
+        By default dictionaries are compared by going down all nested levels. It is possible to configure which keys on each
+        level should be compared (by default we compare all available keys). This is done using the `properties` parameter.
+        It's a list of keys that can be compared or skipped on each level. For example, when comparing route tables snapshots are
+        formatted like:
 
         ```python showLineNumbers
         {
@@ -258,8 +258,9 @@ class SnapshotCompare:
         }
         ```
 
-        The bottom most level keys are:
+        The keys to process here can be:
 
+        - 'default_0.0.0.0/0_ethernet1/3',
         - `virtual-router`,
         - `destination`,
         - `nexthop`,
@@ -405,11 +406,11 @@ class SnapshotCompare:
 
         common_keys = left_side_to_compare.keys() & right_side_to_compare.keys()
         if common_keys:
-            next_level_value = left_side_to_compare[next(iter(common_keys))]
-            at_lowest_level = True if not isinstance(next_level_value, dict) else False
             keys_to_check = (
-                ConfigParser(valid_elements=set(common_keys), requested_config=properties).prepare_config()
-                if at_lowest_level
+                ConfigParser(valid_elements=set(common_keys),
+                             requested_config=properties,
+                             ignore_invalid_config=True).prepare_config()
+                if properties
                 else common_keys
             )
 

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -169,7 +169,7 @@ class ConfigParser:
         * if `requested_config` is `None` we immediately treat it as if `all`  was passed implicitly
             (see [`dialect`](/panos/docs/panos-upgrade-assurance/dialect)) - it's expanded to `valid_elements`
         * `_requested_config_names` is introduced as `requested_config` stripped of any element configurations. Additionally, we
-            do verification if all elements of this variable match `valid_elements`, if not, an exception is thrown by default.
+            do verification if all elements of this variable match `valid_elements`, if they do not, an exception is thrown by default.
             `request_config` is checked at top level level key in case of nested dictionaries within the list.
         * if `ignore_invalid_config` is set to `True`, we ignore any invalid configurations passed in the `requested_config` -
             (no exception thrown) and we remove these invalid configurations from `_requested_config_names` and

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -273,6 +273,27 @@ class TestFirewallProxy:
                         <base-license-name>PA-VM</base-license-name>
                         <authcode />
                     </entry>
+                    <entry>
+                        <feature>Logging Service</feature>
+                        <description>Device Logging Service</description>
+                        <serial>00000000000</serial>
+                        <issued>June 29, 2022</issued>
+                        <expires>August 04, 2024</expires>
+                        <expired>no</expired>
+                        <custom>
+                            <_Log_Storage_TB>7</_Log_Storage_TB>
+                        </custom>
+                        <authcode/>
+                    </entry>
+                    <entry>
+                        <feature>Premium</feature>
+                        <description>24 x 7 phone support; advanced replacement hardware service</description>
+                        <serial>00000000000</serial>
+                        <issued>May 02, 2023</issued>
+                        <expires>June 30, 2028</expires>
+                        <expired>no</expired>
+                        <authcode>12345678</authcode>
+                    </entry>
                 </licenses>
             </result>
         </response>
@@ -281,15 +302,38 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert fw_proxy_mock.get_licenses() == {
-            "PAN-DB URL Filtering": {
-                "authcode": None,
-                "base-license-name": "PA-VM",
-                "description": "Palo Alto Networks URL Filtering " "License",
-                "expired": "no",
-                "expires": "December 31, 2023",
-                "feature": "PAN-DB URL Filtering",
-                "issued": "April 20, 2023",
-                "serial": "00000000000000",
+            'Logging Service': {
+                'authcode': None,
+                'custom': {
+                    '_Log_Storage_TB': '7'
+                },
+                'description': 'Device Logging Service',
+                'expired': 'no',
+                'expires': 'August 04, 2024',
+                'feature': 'Logging Service',
+                'issued': 'June 29, 2022',
+                'serial': '00000000000'
+            },
+            'PAN-DB URL Filtering': {
+                'authcode': None,
+                'base-license-name': 'PA-VM',
+                'description': 'Palo Alto Networks URL Filtering '
+                'License',
+                'expired': 'no',
+                'expires': 'December 31, 2023',
+                'feature': 'PAN-DB URL Filtering',
+                'issued': 'April 20, 2023',
+                'serial': '00000000000000'
+            },
+            'Premium': {
+                'authcode': '12345678',
+                'description': '24 x 7 phone support; advanced replacement '
+                'hardware service',
+                'expired': 'no',
+                'expires': 'June 30, 2028',
+                'feature': 'Premium',
+                'issued': 'May 02, 2023',
+                'serial': '00000000000'
             },
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ class TestConfigParser:
         """Check if exception is raised when ConfigParser is called with unknown param in requested config."""
         with pytest.raises(
             UnknownParameterException,
-            match=r"Unknown configuration parameter passed: .*$",
+            match=r"Unknown configuration parameters passed: .*$",
         ):
             ConfigParser(valid_config_elements, requested_config)
 


### PR DESCRIPTION
## Description

This PR brings a behavioral change in how the requested configurations are processed and fixes below-mentioned issue on comparing dicts with different nested levels.

## Motivation and Context

Fixes #108 

With the change, it is also possible to process elements on each level of a nested dictionary. Considering the following dictionary, it is possible to skip or select a specific license like `["!Logging Service"]` which will skip comparing the "Logging Service" license or provide elements on multiple levels like `["Logging Service", "!custom"]` which will compare only the "Logging Service" license and exclude "custom" element for comparison. Additionally if different sub-dicts have different elements like "custom" element being absent in "PAN-DB URL Filtering", you can specify `["!custom"]` to skip custom key on a dictionary while ignoring it for the other if it doesn't exist. This is achieved by providing an optional `ignore_invalid_config` parameter to `ConfigParser` class.

```json
{
  "license": {
    "Logging Service": {
      "authcode": null,
      "custom": {
        "_Log_Storage_TB": "7"
      },
      "description": "Device Logging Service",
      "expired": "no",
      "expires": "August 04, 2024",
      "feature": "Logging Service",
      "issued": "June 27, 2022",
      "serial": "11111111"
    },
    "PAN-DB URL Filtering": {
      "authcode": null,
      "description": "Palo Alto Networks URL Filtering License",
      "expired": "no",
      "expires": "June 30, 2028",
      "feature": "PAN-DB URL Filtering",
      "issued": "April 29, 2023",
      "serial": "11111111"
    }
  }
}
```

## How Has This Been Tested?

Tested with example scripts.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
