### PR TITLE
Unsupported Transceivers

### DIFF
--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
         "candidate_config",
         "active_support",
         "jobs",
+        "unsupported_transceivers",
         # checks below have optional configuration
         {"ha": {"skip_config_sync": True, "ignore_non_functional": True}},
         {"content_version": {"version": "8635-7675"}},

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional, Union, List, Dict
 from math import ceil
 from datetime import datetime
@@ -902,6 +903,46 @@ class CheckFirewall:
             result.status = CheckStatus.SKIPPED
             result.reason = "No jobs found on device. This is unusual, please investigate."
             return result
+
+    def check_unsupported_transceivers(self) -> CheckResult:
+        """Check for any Optical Transceivers (SFPs or otherwise) that aren't supproted by Palo Alto Networks.
+
+        # Returns
+
+        CheckResult: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking \
+            value of:
+
+        * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) When all optics are OEM and
+            PAN supported
+        * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) otherwise, `CheckResult.reason`
+            field contains information about which Slots and Physical ports currently have unsupported transceivers installed
+        * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when there are no transceiver
+            slots at all.
+        """
+        result = CheckResult()
+
+        system_state = self._node.get_system_state()
+
+        no_sfp_interfaces = True
+        bad_interfaces = []
+        for key, value in system_state.items():
+            if re.match(r"sys\.s[0-9]+\.p[0-9]+\.phy", key):
+                if "'sfp':" in value and "'vendor-name': OEM" not in value:
+                    bad_interfaces.append(key)
+                elif "'sfp'" in value:
+                    no_sfp_interfaces = False
+
+        if bad_interfaces:
+            result.reason = "The following interfaces have non-Palo Alto Networks supported transceivers installed: " + ", ".join(bad_interfaces)
+            return result
+
+        if no_sfp_interfaces:
+            result.status = CheckStatus.SKIPPED
+            result.reason = "No SFP Interfaces were found, or no SFP Transceivers were present in the system."
+            return result
+
+        result.status = CheckStatus.SUCCESS
+        return result
 
     def get_content_db_version(self) -> Dict[str, str]:
         """Get Content DB version.

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -96,6 +96,7 @@ class CheckFirewall:
             CheckType.MP_DP_CLOCK_SYNC: self.check_mp_dp_sync,
             CheckType.CERTS: self.check_ssl_cert_requirements,
             CheckType.JOBS: self.check_non_finished_jobs,
+            CheckType.UNSUPPORTED_TRANSCEIVERS: self.check_unsupported_transceivers
         }
         if not skip_force_locale:
             locale.setlocale(

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1167,3 +1167,33 @@ class FirewallProxy(Firewall):
                 results[jid] = job
 
         return results
+
+    def get_system_state(self) -> dict[str, str]:
+        """Gets the entire output of the show system state command.
+
+        Show system state returns low level information about PAN-OS and the attributes of the system. Note that this function
+        does not parse the data structures beyond the first level.
+
+        The actual API command is `show system state`.
+
+        # Returns
+
+        dict: Each item from the state, where the key is the item key and the value is the value as a string.
+
+        ```python showLineNumbers title="Sample output"
+        {
+            local.name: "mp"
+            local.octeon: "{ }"
+            local.ppid: "0"
+            local.role: "mp"
+            local.slot: "1"
+        }
+        """
+        result = {}
+        show_system_state_str = self.op_parser(cmd="show system state", return_xml=True)
+        for line in show_system_state_str.text.split("\n"):
+            clean_line = line.strip()
+            key, value = clean_line.split(":")[0], ":".join(clean_line.split(":")[1:]).strip()
+            result[key] = value
+
+        return result

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -29,6 +29,7 @@ class CheckType:
     MP_DP_CLOCK_SYNC = "planes_clock_sync"
     CERTS = "certificates_requirements"
     JOBS = "jobs"
+    UNSUPPORTED_TRANSCEIVERS = "unsupported_transceivers"
 
 
 class SnapType:

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -429,6 +429,56 @@ class TestCheckFirewall:
             reason="NTP synchronization in unknown state: unknown."
         )
 
+    def test_check_unsupported_transceivers_not_oem(self, check_firewall_mock):
+        check_firewall_mock._node.get_system_state.return_value = {
+            '': '',
+            'local.brdagent': '{ }',
+            'local.family': 'vm',
+            'local.info': "{ 'family': vm, 'model': PA-VM, 'name': mp, 'ppid': 0, 'role': mp, 'slot': 1, }",
+            'local.model': 'PA-VM', 'local.name': 'mp', 'local.octeon': '{ }',
+            'local.ppid': '0',
+            'local.role': 'mp',
+            'local.slot': '1',
+            'sys.s5.p1.phy': "{ 'duration': 3969, 'last-sample': 1970-01-01 08:00:00, 'link-partner': { }, 'media': QSFP-Plus-Fiber, 'sfp': { 'ch1': { 'rx-power': 0.00 mW, }, 'ch2': { 'rx-power': 0.00 mW, }, 'ch3': { 'rx-power': 0.00 mW, }, 'ch4': { 'rx-power': 0.00 mW, }, 'connector': Reserved, 'diagnostic-monitor': Yes, 'encoding': 64B66B, 'ex-spec-compliance-code': 0x0, 'identifier': QSFPP, 'link-len-km': 0 km, 'link-len-om1': 0 m, 'link-len-om2': 10 m, 'link-len-om3': 10 m, 'link-len-om4': 20 m, 'rx-power-alarm-hi': 0.00 mW, 'rx-power-alarm-lo': 0.00 mW, 'rx-power-warn-hi': 0.00 mW, 'rx-power-warn-lo': 0.00 mW, 'transceiver': S dist,SN,M5, 'vendor-name': FINISAR CORP    , 'vendor-part-number': FCBN410QB1C10   , 'vendor-part-rev': B , 'vendor-serial-number': YYYYYYY         , }, 'type': Ethernet, }",
+            'sys.s6.p2.phy': "{ 'duration': 3969, 'last-sample': 1970-01-01 08:00:00, 'link-partner': { }, 'media': QSFP-Plus-Fiber, 'sfp': { 'ch1': { 'rx-power': 0.00 mW, }, 'ch2': { 'rx-power': 0.00 mW, }, 'ch3': { 'rx-power': 0.00 mW, }, 'ch4': { 'rx-power': 0.00 mW, }, 'connector': Reserved, 'diagnostic-monitor': Yes, 'encoding': 64B66B, 'ex-spec-compliance-code': 0x0, 'identifier': QSFPP, 'link-len-km': 0 km, 'link-len-om1': 0 m, 'link-len-om2': 10 m, 'link-len-om3': 10 m, 'link-len-om4': 20 m, 'rx-power-alarm-hi': 0.00 mW, 'rx-power-alarm-lo': 0.00 mW, 'rx-power-warn-hi': 0.00 mW, 'rx-power-warn-lo': 0.00 mW, 'transceiver': S dist,SN,M5, 'vendor-name': FINISAR CORP    , 'vendor-part-number': FCBN410QB1C10   , 'vendor-part-rev': B , 'vendor-serial-number': YYYYYYY         , }, 'type': Ethernet, }",
+        }
+        assert check_firewall_mock.check_unsupported_transceivers() == CheckResult(
+            reason="The following interfaces have non-Palo Alto Networks supported transceivers installed: sys.s5.p1.phy, sys.s6.p2.phy",
+        )
+
+    def test_check_unsupported_transceivers_all_supported(self, check_firewall_mock):
+        check_firewall_mock._node.get_system_state.return_value = {
+            '': '',
+            'local.brdagent': '{ }',
+            'local.family': 'vm',
+            'local.info': "{ 'family': vm, 'model': PA-VM, 'name': mp, 'ppid': 0, 'role': mp, 'slot': 1, }",
+            'local.model': 'PA-VM', 'local.name': 'mp', 'local.octeon': '{ }',
+            'local.ppid': '0',
+            'local.role': 'mp',
+            'local.slot': '1',
+            'sys.s5.p1.phy': "{ 'link-partner': { }, 'media': SFP-Plus-Fiber, 'sfp': { 'connector': LC, 'encoding': Reserved, 'identifier': SFP, 'transceiver': 10000B-SR, 'vendor-name': OEM , 'vendor-part-number': PAN-SFP-PLUS-SR , 'vendor-part-rev': B4 , }, 'type': Ethernet, }",
+        }
+        assert check_firewall_mock.check_unsupported_transceivers() == CheckResult(
+            status=CheckStatus.SUCCESS
+        )
+
+    def test_check_unsupported_transceivers_no_sfp(self, check_firewall_mock):
+        check_firewall_mock._node.get_system_state.return_value = {
+            '': '',
+            'local.brdagent': '{ }',
+            'local.family': 'vm',
+            'local.info': "{ 'family': vm, 'model': PA-VM, 'name': mp, 'ppid': 0, 'role': mp, 'slot': 1, }",
+            'local.model': 'PA-VM', 'local.name': 'mp', 'local.octeon': '{ }',
+            'local.ppid': '0',
+            'local.role': 'mp',
+            'local.slot': '1',
+            'sys.s4.p20.phy': "{ 'link-partner': { }, 'media': CAT5, 'type': Ethernet, }",
+        }
+        assert check_firewall_mock.check_unsupported_transceivers() == CheckResult(
+            status=CheckStatus.SKIPPED,
+            reason="No SFP Interfaces were found, or no SFP Transceivers were present in the system."
+        )
+
     def test_check_arp_entry_none(self, check_firewall_mock):
         assert check_firewall_mock.check_arp_entry(ip=None) == CheckResult(
             CheckStatus.SKIPPED, reason="Missing ARP table entry description."

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -30,8 +30,8 @@ class TestFirewallProxy:
         cmd = "Example cmd"
 
         assert (
-            fw_proxy_mock.op_parser(cmd)
-            == xml_parse(ET.tostring(raw_response.find("result"), encoding="utf8", method="xml"))["result"]
+                fw_proxy_mock.op_parser(cmd)
+                == xml_parse(ET.tostring(raw_response.find("result"), encoding="utf8", method="xml"))["result"]
         )
 
         fw_proxy_mock.op.assert_called_with(cmd, xml=False, cmd_xml=True, vsys=fw_proxy_mock.vsys)
@@ -349,8 +349,8 @@ class TestFirewallProxy:
             fw_proxy_mock.get_support_license()
 
         assert (
-            str(exception_msg.value)
-            == "Failed to check support info due to Unknown error. Please check network connectivity and try again."
+                str(exception_msg.value)
+                == "Failed to check support info due to Unknown error. Please check network connectivity and try again."
         )
 
     def test_get_support_license_panxapierror_exception(self, fw_proxy_mock):
@@ -883,8 +883,8 @@ class TestFirewallProxy:
         raw_response = ET.fromstring(xml_text)
         fw_proxy_mock.op.return_value = raw_response
         with pytest.raises(
-            MalformedResponseException,
-            match=r"Reported disk space block does not have typical structure: .*$",
+                MalformedResponseException,
+                match=r"Reported disk space block does not have typical structure: .*$",
         ):
             fw_proxy_mock.get_disk_utilization()
 
@@ -901,8 +901,8 @@ class TestFirewallProxy:
         raw_response = ET.fromstring(xml_text)
         fw_proxy_mock.op.return_value = raw_response
         with pytest.raises(
-            MalformedResponseException,
-            match=r"Reported disk space block does not have typical structure: .*$",
+                MalformedResponseException,
+                match=r"Reported disk space block does not have typical structure: .*$",
         ):
             fw_proxy_mock.get_disk_utilization()
 
@@ -1000,8 +1000,8 @@ class TestFirewallProxy:
             fw_proxy_mock.get_available_image_data()
 
         assert (
-            str(exception_msg.value)
-            == "Failed to check upgrade info due to Unknown error. Please check network connectivity and try again."
+                str(exception_msg.value)
+                == "Failed to check upgrade info due to Unknown error. Please check network connectivity and try again."
         )
 
     def test_get_available_image_data_panxapierror_exception(self, fw_proxy_mock):
@@ -1242,3 +1242,38 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert fw_proxy_mock.get_certificates() == {}
+
+    def test_get_system_state(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <![CDATA[local.brdagent: { }
+local.family: vm
+local.info: { 'family': vm, 'model': PA-VM, 'name': mp, 'ppid': 0, 'role': mp, 'slot': 1, }
+local.model: PA-VM
+local.name: mp
+local.octeon: { }
+local.ppid: 0
+local.role: mp
+local.slot: 1
+sys.s6.p1.phy: { 'duration': 3969, 'last-sample': 1970-01-01 08:00:00, 'link-partner': { }, 'media': QSFP-Plus-Fiber, 'sfp': { 'ch1': { 'rx-power': 0.00 mW, }, 'ch2': { 'rx-power': 0.00 mW, }, 'ch3': { 'rx-power': 0.00 mW, }, 'ch4': { 'rx-power': 0.00 mW, }, 'connector': Reserved, 'diagnostic-monitor': Yes, 'encoding': 64B66B, 'ex-spec-compliance-code': 0x0, 'identifier': QSFPP, 'link-len-km': 0 km, 'link-len-om1': 0 m, 'link-len-om2': 10 m, 'link-len-om3': 10 m, 'link-len-om4': 20 m, 'rx-power-alarm-hi': 0.00 mW, 'rx-power-alarm-lo': 0.00 mW, 'rx-power-warn-hi': 0.00 mW, 'rx-power-warn-lo': 0.00 mW, 'transceiver': S dist,SN,M5, 'vendor-name': FINISAR CORP    , 'vendor-part-number': FCBN410QB1C10   , 'vendor-part-rev': B , 'vendor-serial-number': YYYYYYY         , }, 'type': Ethernet, }
+]]>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        system_state_dict = fw_proxy_mock.get_system_state()
+
+        assert system_state_dict == {
+            '': '',
+            'local.brdagent': '{ }',
+            'local.family': 'vm',
+            'local.info': "{ 'family': vm, 'model': PA-VM, 'name': mp, 'ppid': 0, 'role': mp, 'slot': 1, }",
+            'local.model': 'PA-VM', 'local.name': 'mp', 'local.octeon': '{ }',
+            'local.ppid': '0',
+            'local.role': 'mp',
+            'local.slot': '1',
+            'sys.s6.p1.phy': "{ 'duration': 3969, 'last-sample': 1970-01-01 08:00:00, 'link-partner': { }, 'media': QSFP-Plus-Fiber, 'sfp': { 'ch1': { 'rx-power': 0.00 mW, }, 'ch2': { 'rx-power': 0.00 mW, }, 'ch3': { 'rx-power': 0.00 mW, }, 'ch4': { 'rx-power': 0.00 mW, }, 'connector': Reserved, 'diagnostic-monitor': Yes, 'encoding': 64B66B, 'ex-spec-compliance-code': 0x0, 'identifier': QSFPP, 'link-len-km': 0 km, 'link-len-om1': 0 m, 'link-len-om2': 10 m, 'link-len-om3': 10 m, 'link-len-om4': 20 m, 'rx-power-alarm-hi': 0.00 mW, 'rx-power-alarm-lo': 0.00 mW, 'rx-power-warn-hi': 0.00 mW, 'rx-power-warn-lo': 0.00 mW, 'transceiver': S dist,SN,M5, 'vendor-name': FINISAR CORP    , 'vendor-part-number': FCBN410QB1C10   , 'vendor-part-rev': B , 'vendor-serial-number': YYYYYYY         , }, 'type': Ethernet, }",
+        }


### PR DESCRIPTION
## Description

In certain software versions, following an upgrade, it's observed that non-OEM Transceivers (SFPs) can become non-functional after a software upgrade. The `unsupported_transceiver` test fails when any such transceiver is found in output of "show system state".

## Motivation and Context

If a user upgrades and is using unsupported transceivers that become unrecognized by the system, this is a potential major issue that could a severe network outage.

There are two major points up for debate before we can finish this test:

* The majority of our customers may use non-OEM SFPs, which would mean this test fails all the time. As far as I can find, there is no further way to narrow down this test to a specific software version. Is this ok?
* After looking at some real examples, there are optics that are listed in [support documentation](https://live.paloaltonetworks.com/t5/operations-documentation/hw-accessory-cross-reference-810-000077-0az-updated-on-04-25/ta-p/63422) as "supported" but are not shown as "OEM" in the output of system state, so the test as implemented here would incorrectly mark them as failed. We could implement this list in code, but then we would be responsible for keeping it in sync which might not be good.

## How Has This Been Tested?

* Unit tests using real - though truncated -  `show system state` details

The tests have been run against vm-series firewalls but of course they don't have SFPs so we can't fully validate this without a live hardware lab.

## Types of changes

- New feature (non-breaking change which adds functionality)
