### PR TITLE
chore: standard semantic release rules

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,26 +3,7 @@
     "main"
   ],
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "releaseRules": [
-          {
-            "breaking": true,
-            "release": "minor"
-          },
-          {
-            "type": "feat",
-            "release": "patch"
-          },
-          {
-            "type": "feat",
-            "scope" : "MAJOR",
-            "release": "major"
-          }
-        ]
-      }
-    ],
+    "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/git",


### PR DESCRIPTION
## Description

Remove the custom release version calculation rules: feat -> patch, braking -> minor, feat(MAJOR) -> major.

## Motivation and Context

There were no braking changes recently, we can assume the code is major enough not to produce tons of major versions. 
We also need to align the rules for calculating releases with [`pan-os-ansible`](https://github.com/PaloAltoNetworks/pan-os-ansible) project.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
