### PR TITLE
ci: downgrade black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pyopenssl = "^23.2"
 [tool.poetry.group.dev.dependencies]
 pydoc-markdown = "^4.6"
 flake8 = "^5"
-black = "^23.3"
+black = "23.11"
 bandit = "^1.7"
 flake8-pyproject = "^1.2"
 pytest = "^7.2.1"


### PR DESCRIPTION
## Description

Downgrade black

## Motivation and Context

Latest black release causes the following error (reproducible both locally and during CI run)
![image](https://github.com/PaloAltoNetworks/pan-os-upgrade-assurance/assets/42772730/9555b0e6-9f86-448e-9732-28b35e662e7c)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
