### PR TITLE
fix: Add Packaging as python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pan-os-python = "^1.8"
 pan-python = "^0.17"
 xmltodict = "^0.12"
 pyopenssl = "^23.2"
+packaging = "^23.2"
 
 [tool.poetry.group.dev.dependencies]
 pydoc-markdown = "^4.6"


### PR DESCRIPTION
## Description

Adds Packaging as a python dependency.

Packaging simplifies the version comparison functionality of any test that needs to compare two arbitrary PAN-OS software versions.

It's maintained by Pypa, so should present a stable interface.