### PR TITLE
fix: lower packaging version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pan-os-python = "^1.8"
 pan-python = "^0.17"
 xmltodict = "^0.12"
 pyopenssl = "^23.2"
-packaging = ">=21.0"
+packaging = ">=22.0"
 
 [tool.poetry.group.dev.dependencies]
 pydoc-markdown = "^4.6"


### PR DESCRIPTION
## Description

This PR lowers the packaging version in dependencies to increase interoperability with other packages. 
Some python packages have lower `packaging` dependency requirements which results in a conflict to install together.

## How Has This Been Tested?

Tested with `examples/readiness_checks/run_health_checks.py` script.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
