### PR TITLE
fix: route snapshot missing entries fix

### DIFF
--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -504,7 +504,7 @@ Get route table entries, either retrieved from DHCP or configured manually.
 
 The actual API command is `show routing route`.
 
-In the returned `dict` the key is made of three route properties delimited with an underscore (`_`) in the following
+In the returned `dict` the key is made of four route properties delimited with an underscore (`_`) in the following
 order:
 
 * virtual router name,
@@ -1230,6 +1230,16 @@ Get the information from the forwarding information table (FIB).
 
 The actual API command run is `show routing fib`.
 
+In the returned `dict` the key is made of three route properties delimited with an underscore (`_`) in the following
+order:
+
+* destination CIDR,
+* network interface name,
+* next-hop address or name.
+
+The key does not provide any meaningful information, it's there only to introduce uniqueness for each entry. All
+properties that make a key are also available in the value of a dictionary element.
+
 __Returns__
 
 
@@ -1237,7 +1247,7 @@ __Returns__
 
 ```python showLineNumbers title="Sample output"
 {
-    '0.0.0.0/0_ethernet1/1': {
+    '0.0.0.0/0_ethernet1/1_10.10.11.1': {
         'Destination': '0.0.0.0/0',
         'Interface': 'ethernet1/1',
         'Next Hop Type': '0',
@@ -1245,7 +1255,7 @@ __Returns__
         'Next Hop': '10.10.11.1',
         'MTU': '1500'
     },
-    '1.1.1.1/32_loopback.10': {
+    '1.1.1.1/32_loopback.10_0.0.0.0': {
         'Destination': '1.1.1.1/32',
         'Interface': 'loopback.10',
         'Next Hop Type': '3',

--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -509,14 +509,15 @@ order:
 
 * virtual router name,
 * destination CIDR,
-* network interface name if one is available, empty string otherwise.
+* network interface name if one is available, empty string otherwise,
+* next-hop address or name.
 
 The key does not provide any meaningful information, it's there only to introduce uniqueness for each entry. All
 properties that make a key are also available in the value of a dictionary element.
 
 ```python showLineNumbers title="Sample output"
 {
-    private_0.0.0.0/0_private/i3': {
+    private_0.0.0.0/0_private/i3_vr-public': {
         'age': None,
         'destination': '0.0.0.0/0',
         'flags': 'A S',
@@ -526,7 +527,7 @@ properties that make a key are also available in the value of a dictionary eleme
         'route-table': 'unicast',
         'virtual-router': 'private'
     },
-    'public_10.0.0.0/8_public/i3': {
+    'public_10.0.0.0/8_public/i3_vr-private': {
         'age': None,
         'destination': '10.0.0.0/8',
         'flags': 'A S',

--- a/docs/panos-upgrade-assurance/api/snapshot_compare.md
+++ b/docs/panos-upgrade-assurance/api/snapshot_compare.md
@@ -202,7 +202,7 @@ when comparing route tables snapshots are formatted like:
 ```python showLineNumbers
 {
     "routes": {
-        "default_0.0.0.0/0_ethernet1/3": {
+        "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
             "virtual-router": "default",
             "destination": "0.0.0.0/0",
             "nexthop": "10.26.129.129",
@@ -376,7 +376,7 @@ To illustrate that, the `passed` flag added by this method is highlighted:
     },
     'missing': {
         'missing_keys': [
-            'default_0.0.0.0/0_ethernet1/3'
+            'default_0.0.0.0/0_ethernet1/3_10.26.129.129'
         ],
         'passed': False
     },
@@ -427,21 +427,21 @@ An example for the route tables, crafted in a way that almost each level fails:
 {
     "added": {
         "added_keys": [
-            "default_10.26.129.0/25_ethernet1/2",
-            "default_168.63.129.16/32_ethernet1/3"
+            "default_10.26.129.0/25_ethernet1/2_10.26.129.1",
+            "default_168.63.129.16/32_ethernet1/3_10.26.129.129"
         ],
         "passed": "False"
     },
     "missing": {
         "missing_keys": [
-            "default_0.0.0.0/0_ethernet1/3"
+            "default_0.0.0.0/0_ethernet1/3_10.26.129.129"
         ],
         "passed": "False"
     },
     "changed": {
         # highlight-start
         "changed_raw": {
-            "default_10.26.130.0/25_ethernet1/2": {
+            "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
                 "added": {
                     "added_keys": [],
                     "passed": "True"

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -919,7 +919,7 @@ The sample output containing a snapshot for *route tables*, *licenses*, and *IPS
     },
   }.
   "routes": {
-    "default_0.0.0.0/0_ethernet1/3": {
+    "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
       "virtual-router": "default",
       "destination": "0.0.0.0/0",
       "nexthop": "10.26.129.129",

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -966,6 +966,7 @@ snapshots_config = [
   'content_version',
   'session_stats',
   'ip_sec_tunnels',
+  'fib_routes',
 ]
 ```
 
@@ -983,6 +984,7 @@ snapshots_config:
   - content_version
   - session_stats
   - ip_sec_tunnels
+  - fib_routes
 ```
 
 ```mdx-code-block
@@ -1070,6 +1072,10 @@ reports = [
         'properties': ['!flags'],
         'count_change_threshold': 10
     }},
+    {'fib_routes': {
+        'properties': ['!flags'],
+        'count_change_threshold': 10
+    }},
     'content_version',
     {'session_stats': {
         'thresholds': [
@@ -1100,6 +1106,10 @@ reports:
       properties:
         - "!serial"
   - routes:
+      properties:
+        - "!flags"
+      count_change_threshold: 10
+  - fib_routes:
       properties:
         - "!flags"
       count_change_threshold: 10

--- a/examples/readiness_checks/run_readiness_snapshot.py
+++ b/examples/readiness_checks/run_readiness_snapshot.py
@@ -82,6 +82,7 @@ if __name__ == "__main__":
         # 'all',
         "nics",
         "routes",
+        "fib_routes",
         "license",
         "arp_table",
         "content_version",

--- a/examples/report/fw1.snapshot
+++ b/examples/report/fw1.snapshot
@@ -26,7 +26,7 @@
     }
   },
   "routes": {
-    "default_0.0.0.0/0_ethernet1/3": {
+    "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
       "virtual-router": "default",
       "destination": "0.0.0.0/0",
       "nexthop": "10.26.129.129",
@@ -36,7 +36,7 @@
       "interface": "ethernet1/3",
       "route-table": "unicast"
     },
-    "default_10.26.129.0/25_ethernet1/2": {
+    "default_10.26.129.0/25_ethernet1/2_10.26.129.1": {
       "virtual-router": "default",
       "destination": "10.26.129.0/25",
       "nexthop": "10.26.129.1",
@@ -46,7 +46,7 @@
       "interface": "ethernet1/2",
       "route-table": "unicast"
     },
-    "default_10.26.130.0/25_ethernet1/2": {
+    "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
       "virtual-router": "default",
       "destination": "10.26.130.0/25",
       "nexthop": "10.26.129.1",
@@ -56,7 +56,7 @@
       "interface": "ethernet1/2",
       "route-table": "unicast"
     },
-    "default_168.63.129.16/32_ethernet1/3": {
+    "default_168.63.129.16/32_ethernet1/3_10.26.129.129": {
       "virtual-router": "default",
       "destination": "168.63.129.16/32",
       "nexthop": "10.26.129.129",

--- a/examples/report/fw2.snapshot
+++ b/examples/report/fw2.snapshot
@@ -13,7 +13,7 @@
     }
   },
   "routes": {
-    "default_0.0.0.0/0_ethernet1/3": {
+    "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
       "virtual-router": "default",
       "destination": "0.0.0.0/0",
       "nexthop": "10.26.129.129",
@@ -23,7 +23,7 @@
       "interface": "ethernet1/3",
       "route-table": "unicast"
     },
-    "default_10.26.129.0/25_ethernet1/2": {
+    "default_10.26.129.0/25_ethernet1/2_10.26.129.1": {
       "virtual-router": "default",
       "destination": "10.26.129.0/25",
       "nexthop": "10.26.129.1",
@@ -33,7 +33,7 @@
       "interface": "ethernet1/2",
       "route-table": "unicast"
     },
-    "default_10.26.130.0/25_ethernet1/2": {
+    "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
       "virtual-router": "default",
       "destination": "10.26.130.0/25",
       "nexthop": "10.26.129.1",
@@ -43,7 +43,7 @@
       "interface": "ethernet1/2",
       "route-table": "unicast"
     },
-    "default_168.63.129.16/32_ethernet1/3": {
+    "default_168.63.129.16/32_ethernet1/3_10.26.129.129": {
       "virtual-router": "default",
       "destination": "168.63.129.16/32",
       "nexthop": "10.26.129.129",

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -605,8 +605,12 @@ class FirewallProxy:
             routes = response["entry"]
             for route in routes if isinstance(routes, list) else [routes]:
                 result[
-                    f"{route['virtual-router']}_{route['destination']}_{route['interface'] if route['interface'] else ''}_\
-                    {route['nexthop'].replace(' ', '-')}"
+                    (
+                        f"{route['virtual-router']}_"
+                        f"{route['destination']}_"
+                        f"{route['interface'] if route['interface'] else ''}_"
+                        f"{route['nexthop'].replace(' ', '-')}"
+                    )
                 ] = dict(route)
 
         return result

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -606,7 +606,7 @@ class FirewallProxy:
             for route in routes if isinstance(routes, list) else [routes]:
                 result[
                     (
-                        f"{route['virtual-router']}_"
+                        f"{route['virtual-router'].replace(' ', '-')}_"
                         f"{route['destination']}_"
                         f"{route['interface'] if route['interface'] else ''}_"
                         f"{route['nexthop'].replace(' ', '-')}"

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -604,7 +604,8 @@ class FirewallProxy:
             routes = response["entry"]
             for route in routes if isinstance(routes, list) else [routes]:
                 result[
-                    f"{route['virtual-router']}_{route['destination']}_{route['interface'] if route['interface'] else ''}"
+                    f"{route['virtual-router']}_{route['destination']}_{route['interface'] if route['interface'] else ''}_\
+                    {route['nexthop'].replace(' ', '-')}"
                 ] = dict(route)
 
         return result

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -556,7 +556,7 @@ class FirewallProxy:
 
         The actual API command is `show routing route`.
 
-        In the returned `dict` the key is made of three route properties delimited with an underscore (`_`) in the following
+        In the returned `dict` the key is made of four route properties delimited with an underscore (`_`) in the following
         order:
 
         * virtual router name,
@@ -1415,13 +1415,23 @@ class FirewallProxy:
 
         The actual API command run is `show routing fib`.
 
+        In the returned `dict` the key is made of three route properties delimited with an underscore (`_`) in the following
+        order:
+
+        * destination CIDR,
+        * network interface name,
+        * next-hop address or name.
+
+        The key does not provide any meaningful information, it's there only to introduce uniqueness for each entry. All
+        properties that make a key are also available in the value of a dictionary element.
+
         # Returns
 
         dict: Status of the route entries in the FIB
 
         ```python showLineNumbers title="Sample output"
         {
-            '0.0.0.0/0_ethernet1/1': {
+            '0.0.0.0/0_ethernet1/1_10.10.11.1': {
                 'Destination': '0.0.0.0/0',
                 'Interface': 'ethernet1/1',
                 'Next Hop Type': '0',
@@ -1429,7 +1439,7 @@ class FirewallProxy:
                 'Next Hop': '10.10.11.1',
                 'MTU': '1500'
             },
-            '1.1.1.1/32_loopback.10': {
+            '1.1.1.1/32_loopback.10_0.0.0.0': {
                 'Destination': '1.1.1.1/32',
                 'Interface': 'loopback.10',
                 'Next Hop Type': '3',
@@ -1455,7 +1465,7 @@ class FirewallProxy:
 
                 for entry in entries if isinstance(entries, list) else [entries]:
                     if isinstance(entry, dict):
-                        key = f'{entry["dst"]}_{entry["interface"]}'
+                        key = f'{entry["dst"]}_{entry["interface"]}_{entry["nexthop"]}'
                         result_entry = {
                             "Destination": entry.get("dst"),
                             "Interface": entry.get("interface"),

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -561,14 +561,15 @@ class FirewallProxy:
 
         * virtual router name,
         * destination CIDR,
-        * network interface name if one is available, empty string otherwise.
+        * network interface name if one is available, empty string otherwise,
+        * next-hop address or name.
 
         The key does not provide any meaningful information, it's there only to introduce uniqueness for each entry. All
         properties that make a key are also available in the value of a dictionary element.
 
         ```python showLineNumbers title="Sample output"
         {
-            private_0.0.0.0/0_private/i3': {
+            private_0.0.0.0/0_private/i3_vr-public': {
                 'age': None,
                 'destination': '0.0.0.0/0',
                 'flags': 'A S',
@@ -578,7 +579,7 @@ class FirewallProxy:
                 'route-table': 'unicast',
                 'virtual-router': 'private'
             },
-            'public_10.0.0.0/8_public/i3': {
+            'public_10.0.0.0/8_public/i3_vr-private': {
                 'age': None,
                 'destination': '10.0.0.0/8',
                 'flags': 'A S',

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -246,7 +246,7 @@ class SnapshotCompare:
         ```python showLineNumbers
         {
             "routes": {
-                "default_0.0.0.0/0_ethernet1/3": {
+                "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
                     "virtual-router": "default",
                     "destination": "0.0.0.0/0",
                     "nexthop": "10.26.129.129",
@@ -467,7 +467,7 @@ class SnapshotCompare:
             },
             'missing': {
                 'missing_keys': [
-                    'default_0.0.0.0/0_ethernet1/3'
+                    'default_0.0.0.0/0_ethernet1/3_10.26.129.129'
                 ],
                 'passed': False
             },
@@ -520,21 +520,21 @@ class SnapshotCompare:
         {
             "added": {
                 "added_keys": [
-                    "default_10.26.129.0/25_ethernet1/2",
-                    "default_168.63.129.16/32_ethernet1/3"
+                    "default_10.26.129.0/25_ethernet1/2_10.48.6.1",
+                    "default_168.63.129.16/32_ethernet1/3_10.26.129.129"
                 ],
                 "passed": "False"
             },
             "missing": {
                 "missing_keys": [
-                    "default_0.0.0.0/0_ethernet1/3"
+                    "default_0.0.0.0/0_ethernet1/3_10.26.129.129"
                 ],
                 "passed": "False"
             },
             "changed": {
                 # highlight-start
                 "changed_raw": {
-                    "default_10.26.130.0/25_ethernet1/2": {
+                    "default_10.26.130.0/25_ethernet1/2_10.48.6.1": {
                         "added": {
                             "added_keys": [],
                             "passed": "True"

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -520,7 +520,7 @@ class SnapshotCompare:
         {
             "added": {
                 "added_keys": [
-                    "default_10.26.129.0/25_ethernet1/2_10.48.6.1",
+                    "default_10.26.129.0/25_ethernet1/2_10.26.129.1",
                     "default_168.63.129.16/32_ethernet1/3_10.26.129.129"
                 ],
                 "passed": "False"
@@ -534,7 +534,7 @@ class SnapshotCompare:
             "changed": {
                 # highlight-start
                 "changed_raw": {
-                    "default_10.26.130.0/25_ethernet1/2_10.48.6.1": {
+                    "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
                         "added": {
                             "added_keys": [],
                             "passed": "True"

--- a/tests/snapshots.py
+++ b/tests/snapshots.py
@@ -26,7 +26,7 @@ snap1 = {
         },
     },
     "routes": {
-        "default_0.0.0.0/0_ethernet1/3": {
+        "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
             "virtual-router": "default",
             "destination": "0.0.0.0/0",
             "nexthop": "10.26.129.129",
@@ -36,7 +36,7 @@ snap1 = {
             "interface": "ethernet1/3",
             "route-table": "unicast",
         },
-        "default_10.26.129.0/25_ethernet1/2": {
+        "default_10.26.129.0/25_ethernet1/2_10.26.129.1": {
             "virtual-router": "default",
             "destination": "10.26.129.0/25",
             "nexthop": "10.26.129.1",
@@ -46,7 +46,7 @@ snap1 = {
             "interface": "ethernet1/2",
             "route-table": "unicast",
         },
-        "default_10.26.130.0/25_ethernet1/2": {
+        "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
             "virtual-router": "default",
             "destination": "10.26.130.0/25",
             "nexthop": "10.26.129.1",
@@ -56,7 +56,7 @@ snap1 = {
             "interface": "ethernet1/2",
             "route-table": "unicast",
         },
-        "default_168.63.129.16/32_ethernet1/3": {
+        "default_168.63.129.16/32_ethernet1/3_10.26.129.129": {
             "virtual-router": "default",
             "destination": "168.63.129.16/32",
             "nexthop": "10.26.129.129",
@@ -236,7 +236,7 @@ snap2 = {
         }
     },
     "routes": {
-        "default_0.0.0.0/0_ethernet1/3": {
+        "default_0.0.0.0/0_ethernet1/3_10.26.129.129": {
             "virtual-router": "default",
             "destination": "0.0.0.0/0",
             "nexthop": "10.26.129.129",
@@ -246,7 +246,7 @@ snap2 = {
             "interface": "ethernet1/3",
             "route-table": "unicast",
         },
-        "default_10.26.129.0/25_ethernet1/2": {
+        "default_10.26.129.0/25_ethernet1/2_10.26.129.1": {
             "virtual-router": "default",
             "destination": "10.26.129.0/25",
             "nexthop": "10.26.129.1",
@@ -256,7 +256,7 @@ snap2 = {
             "interface": "ethernet1/2",
             "route-table": "unicast",
         },
-        "default_10.26.130.0/25_ethernet1/2": {
+        "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
             "virtual-router": "default",
             "destination": "10.26.130.0/25",
             "nexthop": "10.26.129.1",
@@ -266,7 +266,7 @@ snap2 = {
             "interface": "ethernet1/2",
             "route-table": "unicast",
         },
-        "default_168.63.129.16/32_ethernet1/3": {
+        "default_168.63.129.16/32_ethernet1/3_10.26.129.129": {
             "virtual-router": "default",
             "destination": "168.63.129.16/32",
             "nexthop": "10.26.129.129",

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -562,7 +562,6 @@ class TestFirewallProxy:
             },
         }
 
-
     def test_get_arp_table(self, fw_proxy_mock):
         xml_text = """
         <response status="success">

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1821,7 +1821,7 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert fw_proxy_mock.get_fib() == {
-            "0.0.0.0/0_ethernet1/1": {
+            "0.0.0.0/0_ethernet1/1_10.10.11.1": {
                 "Destination": "0.0.0.0/0",
                 "Interface": "ethernet1/1",
                 "Next Hop Type": "0",
@@ -1829,7 +1829,7 @@ class TestFirewallProxy:
                 "Next Hop": "10.10.11.1",
                 "MTU": "1500",
             },
-            "1.1.1.1/32_loopback.10": {
+            "1.1.1.1/32_loopback.10_1.2.3.4": {
                 "Destination": "1.1.1.1/32",
                 "Interface": "loopback.10",
                 "Next Hop Type": "3",

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -470,6 +470,99 @@ class TestFirewallProxy:
             },
         }
 
+    def test_get_routes_same_dest(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <flags>flags: A:active, ?:loose, C:connect, H:host, S:static, ~:internal, R:rip, O:ospf,
+                    B:bgp, Oi:ospf intra-area, Oo:ospf inter-area, O1:ospf ext-type-1, O2:ospf ext-type-2,
+                    E:ecmp, M:multicast</flags>
+                <entry>
+                    <virtual-router>default</virtual-router>
+                    <destination>0.0.0.0/0</destination>
+                    <nexthop>10.10.11.1</nexthop>
+                    <metric>10</metric>
+                    <flags>A S E </flags>
+                    <age />
+                    <interface>ethernet1/1</interface>
+                    <route-table>unicast</route-table>
+                </entry>
+                <entry>
+                    <virtual-router>default</virtual-router>
+                    <destination>0.0.0.0/0</destination>
+                    <nexthop>10.10.12.1</nexthop>
+                    <metric>10</metric>
+                    <flags>A S E </flags>
+                    <age />
+                    <interface>ethernet1/1</interface>
+                    <route-table>unicast</route-table>
+                </entry>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_routes() == {
+            "default_0.0.0.0/0_ethernet1/1_10.10.11.1": {
+                "age": None,
+                "destination": "0.0.0.0/0",
+                "flags": "A S E",
+                "interface": "ethernet1/1",
+                "metric": "10",
+                "nexthop": "10.10.11.1",
+                "route-table": "unicast",
+                "virtual-router": "default",
+            },
+            "default_0.0.0.0/0_ethernet1/1_10.10.12.1": {
+                "age": None,
+                "destination": "0.0.0.0/0",
+                "flags": "A S E",
+                "interface": "ethernet1/1",
+                "metric": "10",
+                "nexthop": "10.10.12.1",
+                "route-table": "unicast",
+                "virtual-router": "default",
+            },
+        }
+
+    def test_get_routes_nexthop_name(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <flags>flags: A:active, ?:loose, C:connect, H:host, S:static, ~:internal, R:rip, O:ospf,
+                    B:bgp, Oi:ospf intra-area, Oo:ospf inter-area, O1:ospf ext-type-1, O2:ospf ext-type-2,
+                    E:ecmp, M:multicast</flags>
+                <entry>
+                    <virtual-router>default</virtual-router>
+                    <destination>0.0.0.0/0</destination>
+                    <nexthop>public vr</nexthop>
+                    <metric>10</metric>
+                    <flags>A S E </flags>
+                    <age />
+                    <interface>ethernet1/1</interface>
+                    <route-table>unicast</route-table>
+                </entry>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_routes() == {
+            "default_0.0.0.0/0_ethernet1/1_public-vr": {
+                "age": None,
+                "destination": "0.0.0.0/0",
+                "flags": "A S E",
+                "interface": "ethernet1/1",
+                "metric": "10",
+                "nexthop": "public vr",
+                "route-table": "unicast",
+                "virtual-router": "default",
+            },
+        }
+
+
     def test_get_arp_table(self, fw_proxy_mock):
         xml_text = """
         <response status="success">

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -458,7 +458,7 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert fw_proxy_mock.get_routes() == {
-            "default_0.0.0.0/0_ethernet1/1": {
+            "default_0.0.0.0/0_ethernet1/1_10.10.11.1": {
                 "age": None,
                 "destination": "0.0.0.0/0",
                 "flags": "A S E",

--- a/tests/test_snapshot_compare.py
+++ b/tests/test_snapshot_compare.py
@@ -386,7 +386,7 @@ class TestSnapshotCompare:
                         "added": {"added_keys": [], "passed": True},
                         "changed": {
                             "changed_raw": {
-                                "default_10.26.130.0/25_ethernet1/2": {
+                                "default_10.26.130.0/25_ethernet1/2_10.26.129.1": {
                                     "added": {"added_keys": [], "passed": True},
                                     "changed": {
                                         "changed_raw": {"flags": {"left_snap": "A S", "right_snap": "A"}},


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The route table snapshot was missing entries when ECMP routes (differed only by next-hop) were present. This was because dict key generation was based only on VR name, destination CIDR and interface (if applicable). This PR adds next-hop IP address or name to dict key, so the keys are unique every time.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#56 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested with example python scripts.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
