### PR TITLE
fix(firewall_proxy/is_panorama_connected): Added fix for panorama check for FWs in version PAN-OS 11 or later

### DIFF
--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -262,6 +262,11 @@ class FirewallProxy:
                 pan_connected = interpret_yes_no((pan_status_list[i].split(":")[1]).strip())
                 if pan_connected:
                     return True
+        elif pan_status_list_length in [3, 6]:
+            for i in range(1, pan_status_list_length, 3):
+                pan_connected = interpret_yes_no((pan_status_list[i].split(":")[1]).strip())
+                if pan_connected:
+                    return True
         else:
             raise exceptions.MalformedResponseException(
                 f"Panorama configuration block does not have typical structure: <{pan_status}>."

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -254,7 +254,7 @@ class FirewallProxy:
         if not isinstance(pan_status, str):
             raise exceptions.MalformedResponseException("Response from device is not type of string.")
 
-        panorama_connection_pattern = r'connected\s*:\s*(yes|no)'
+        panorama_connection_pattern = r"connected\s*:\s*(yes|no)"
         match = re.search(panorama_connection_pattern, pan_status, re.IGNORECASE)
         if match:
             status = match.group(1).strip()

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -254,20 +254,15 @@ class FirewallProxy:
         if not isinstance(pan_status, str):
             raise exceptions.MalformedResponseException("Response from device is not type of string.")
 
-        pan_status_list = list(filter(None, pan_status.split("\n")))
-        pan_status_list_length = len(pan_status_list)
-
-        if pan_status_list_length in [3, 6]:
-            for i in range(1, pan_status_list_length, 3):
-                pan_connected = interpret_yes_no((pan_status_list[i].split(":")[1]).strip())
-                if pan_connected:
-                    return True
+        panorama_connection_pattern = r'connected\s*:\s*(yes|no)'
+        match = re.search(panorama_connection_pattern, pan_status, re.IGNORECASE)
+        if match:
+            status = match.group(1).strip()
+            return interpret_yes_no(status)
         else:
             raise exceptions.MalformedResponseException(
                 f"Panorama configuration block does not have typical structure: <{pan_status}>."
             )
-
-        return False
 
     def get_ha_configuration(self) -> dict:
         """Get high-availability configuration status.

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -254,15 +254,10 @@ class FirewallProxy:
         if not isinstance(pan_status, str):
             raise exceptions.MalformedResponseException("Response from device is not type of string.")
 
-        pan_status_list = pan_status.split("\n")
+        pan_status_list = list(filter(None, pan_status.split("\n")))
         pan_status_list_length = len(pan_status_list)
 
-        if pan_status_list_length in [3, 7]:
-            for i in range(1, pan_status_list_length, 4):
-                pan_connected = interpret_yes_no((pan_status_list[i].split(":")[1]).strip())
-                if pan_connected:
-                    return True
-        elif pan_status_list_length in [3, 6]:
+        if pan_status_list_length in [3, 6]:
             for i in range(1, pan_status_list_length, 3):
                 pan_connected = interpret_yes_no((pan_status_list[i].split(":")[1]).strip())
                 if pan_connected:

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -254,11 +254,10 @@ class FirewallProxy:
         if not isinstance(pan_status, str):
             raise exceptions.MalformedResponseException("Response from device is not type of string.")
 
-        panorama_connection_pattern = r"connected\s*:\s*(yes|no)"
-        match = re.search(panorama_connection_pattern, pan_status, re.IGNORECASE)
-        if match:
-            status = match.group(1).strip()
-            return interpret_yes_no(status)
+        if re.search(r"connected\s*:\s*yes", pan_status, re.IGNORECASE):
+            return True
+        elif re.search(r"connected\s*:\s*no", pan_status, re.IGNORECASE):
+            return False
         else:
             raise exceptions.MalformedResponseException(
                 f"Panorama configuration block does not have typical structure: <{pan_status}>."


### PR DESCRIPTION
## Description

This PR closes #158 .

FWs in PAN-s 11.0 and later removed a line from the `show panorama-status` op command output:

Pre-version 11.0:

```
<Panorama Server 1 : 10.10.10.5
    Connected     : yes
    HA state      : Active

Panorama Server 2 : 10.10.10.6
    Connected     : yes
    HA state      : Passive>.
```

Version >=11.0:

```
<Panorama Server 1 : 10.10.10.5
    Connected     : yes
    HA state      : Active
Panorama Server 2 : 10.10.10.6
    Connected     : yes
    HA state      : Passive>.
```

This resulted in two different list lengths that did no match the condition properly.

## Motivation and Context

Support for PAN-OS >=11.0 for `is_panorama_connected` check .

## How Has This Been Tested?

Local Example with two different versions:

```
python3 run_readiness_checks.py -d <pan_os_v11> -u admin -p <MY_PASS>
['Panorama Server 1 : 10.10.10.5', '    Connected     : yes', '    HA state      : Active', 'Panorama Server 2 : 10.10.10.6', '    Connected     : yes', '    HA state      : Passive']
 panorama:
   | state: True
   | reason: [SUCCESS]
True [SUCCESS]

python3 run_readiness_checks.py -d <pan_os_v10.2> -u admin -p <MYP_PASS>
['Panorama Server 1 : 10.10.10.5', '    Connected     : yes', '    HA state      : Active', '', 'Panorama Server 2 : 10.10.10.6', '    Connected     : yes', '    HA state      : Passive']
 panorama:
   | state: True
   | reason: [SUCCESS]
False [FAIL] Peer device is not in active or passive state.
```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
