### PR TITLE
ci: fix release unittests permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
   unit_tests:
     name: Validate all Unit Tests pass
     needs: pyversion
+    permissions:
+      contents: write
     uses: ./.github/workflows/sub_unittest.yml
     with:
       python_version: ${{ needs.pyversion.outputs.pyversion }}

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -12,13 +12,6 @@ on:
         type: string
         required: true
 
-
-permissions:
-  # Gives the action the necessary permissions for pushing data to the
-  # python-coverage-comment-action branch, and for editing existing
-  # comments (to avoid publishing multiple comments in the same PR)
-  contents: write
-
 jobs:
 
   unittests:
@@ -45,19 +38,22 @@ jobs:
       - name: Run unit tests and coverage
         run: poetry run make test_coverage
 
+  upload_coverage:
+    name: Upload coverage results to artifact
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+
+    steps:
       # coverage results comment is uploaded to artifact to be written by post PR workflow run
       - name: Coverage comment
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
-        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v4
-        if: |
-          ${{ github.event_name == 'pull_request' &&
-          steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' }}
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -42,6 +42,11 @@ jobs:
     name: Upload coverage results to artifact
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      # Gives the action the necessary permissions for pushing data to the
+      # python-coverage-comment-action branch, and for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
 
     steps:
       # coverage results comment is uploaded to artifact to be written by post PR workflow run

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -12,6 +12,13 @@ on:
         type: string
         required: true
 
+
+permissions:
+  # Gives the action the necessary permissions for pushing data to the
+  # python-coverage-comment-action branch, and for editing existing
+  # comments (to avoid publishing multiple comments in the same PR)
+  contents: write
+
 jobs:
 
   unittests:
@@ -38,27 +45,19 @@ jobs:
       - name: Run unit tests and coverage
         run: poetry run make test_coverage
 
-  upload_coverage:
-    name: Upload coverage results to artifact
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    permissions:
-      # Gives the action the necessary permissions for pushing data to the
-      # python-coverage-comment-action branch, and for editing existing
-      # comments (to avoid publishing multiple comments in the same PR)
-      contents: write
-
-    steps:
       # coverage results comment is uploaded to artifact to be written by post PR workflow run
       - name: Coverage comment
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
+        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v4
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: |
+          ${{ github.event_name == 'pull_request' &&
+          steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' }}
         with:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt


### PR DESCRIPTION
## Description

CI Release workflow failed requiring write access for contents. 

## Motivation and Context

https://github.com/PaloAltoNetworks/pan-os-upgrade-assurance/actions/runs/8073836898

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

CI changes

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
