### PR TITLE
feat: jobs check enhancement

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -529,12 +529,12 @@ __Returns__
 * [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the `test_window` parameter
     does not meet criteria.
 
-### `CheckFirewall.check_jobs`
+### `CheckFirewall.check_non_matching_jobs`
 
 ```python
-def check_jobs(job_type: str = None,
-               job_status: str = "FIN",
-               job_result: str = None) -> CheckResult
+def check_non_matching_jobs(job_type: str = None,
+                            job_status: str = "FIN",
+                            job_result: str = None) -> CheckResult
 ```
 
 Check for any job that does not match with the type, status and result set in the parameters (by default looks for

--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -529,23 +529,27 @@ __Returns__
 * [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the `test_window` parameter
     does not meet criteria.
 
-### `CheckFirewall.check_non_finished_jobs`
+### `CheckFirewall.check_jobs`
 
 ```python
-def check_non_finished_jobs() -> CheckResult
+def check_jobs(job_type: str = None,
+               job_status: str = "FIN",
+               job_result: str = None) -> CheckResult
 ```
 
-Check for any job with status different than FIN.
+Check for any job that does not match with the type, status and result set in the parameters (by default looks for
+jobs with status different than FIN).
 
 __Returns__
 
 
 `CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
 
-* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when all jobs are in FIN state.
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when all jobs match the type,
+    status and result set in the parameters (by default, when all jobs are in FIN state).
 * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) otherwise, `CheckResult.reason`
-    field contains information about the 1<sup>st</sup> job found with status different than FIN (job ID and the actual
-    status).
+    field contains information about the 1<sup>st</sup> job found with type, status or result different than desired (job
+    ID and the actual value).
 * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when there are no jobs on a
     device.
 

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -767,7 +767,7 @@ parameters (by default checks only whether the job status equals to `FIN`), will
 
 Does not require configuration.
 
-**Method**: [`CheckFirewall.check_jobs()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_jobs)
+**Method**: [`CheckFirewall.check_non_matching_jobs()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_non_matching_jobs)
 
 ### `ntp_sync`
 

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -762,12 +762,12 @@ checks_configuration:
 
 ### `jobs`
 
-Verify if there are any running/pending jobs in the job queue. Any job with a status different than `FIN` will cause
-the check to fail.
+Verify if there are any running/pending jobs in the job queue. Any job with a type, status or result different than set in the
+parameters (by default checks only whether the job status equals to `FIN`), will cause the check to fail.
 
 Does not require configuration.
 
-**Method**: [`CheckFirewall.check_non_finished_jobs()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_non_finished_jobs)
+**Method**: [`CheckFirewall.check_jobs()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_jobs)
 
 ### `ntp_sync`
 

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -103,7 +103,7 @@ class CheckFirewall:
             CheckType.MP_DP_CLOCK_SYNC: self.check_mp_dp_sync,
             CheckType.CERTS: self.check_ssl_cert_requirements,
             CheckType.UPDATES: self.check_scheduled_updates,
-            CheckType.JOBS: self.check_jobs,
+            CheckType.JOBS: self.check_non_matching_jobs,
         }
 
         self._health_check_method_mapping = {
@@ -1048,7 +1048,7 @@ class CheckFirewall:
 
         return result
 
-    def check_jobs(self, job_type: str = None, job_status: str = "FIN", job_result: str = None) -> CheckResult:
+    def check_non_matching_jobs(self, job_type: str = None, job_status: str = "FIN", job_result: str = None) -> CheckResult:
         """Check for any job that does not match with the type, status and result set in the parameters (by default looks for
         jobs with status different than FIN).
 
@@ -1079,7 +1079,7 @@ class CheckFirewall:
             for jid, job in all_jobs.items():
                 if job_type and (job["type"] != job_type):
                     result.reason = (
-                        f"At least one job (ID={jid}) does not have a desired type of {job_type} (status={job['type']})."
+                        f"At least one job (ID={jid}) does not have a desired type of {job_type} (type={job['type']})."
                     )
                     return result
                 elif job_status and (job["status"] != job_status):
@@ -1092,9 +1092,8 @@ class CheckFirewall:
                         f"At least one job (ID={jid}) does not have a desired result of {job_result} (result={job['result']})."
                     )
                     return result
-                else:
-                    result.status = CheckStatus.SUCCESS
-                    return result
+            result.status = CheckStatus.SUCCESS
+            return result
         else:
             result.status = CheckStatus.SKIPPED
             result.reason = "No jobs found on device. This is unusual, please investigate."

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -1066,26 +1066,31 @@ class CheckFirewall:
             device.
 
         """
-        
+        result = CheckResult()
+
         if job_type is None and job_status is None and job_result is None:
             result.status = CheckStatus.SKIPPED
             result.reason = "Neither 'job_type', 'job_status' nor 'job_result' parameters were set."
             return result
-        
-        result = CheckResult()
 
         all_jobs = self._node.get_jobs()
 
         if all_jobs:
             for jid, job in all_jobs.items():
                 if job_type and (job["type"] != job_type):
-                    result.reason = f"At least one job (ID={jid}) does not have a desired type of {job_type} (status={job['type']})."
+                    result.reason = (
+                        f"At least one job (ID={jid}) does not have a desired type of {job_type} (status={job['type']})."
+                    )
                     return result
                 elif job_status and (job["status"] != job_status):
-                    result.reason = f"At least one job (ID={jid}) does not have a desired status of {job_status} (status={job['status']})."
+                    result.reason = (
+                        f"At least one job (ID={jid}) does not have a desired status of {job_status} (status={job['status']})."
+                    )
                     return result
                 elif job_result and (job["result"] != job_result):
-                    result.reason = f"At least one job (ID={jid}) does not have a desired result of {job_result} (result={job['result']})."
+                    result.reason = (
+                        f"At least one job (ID={jid}) does not have a desired result of {job_result} (result={job['result']})."
+                    )
                     return result
                 else:
                     result.status = CheckStatus.SUCCESS

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -1061,7 +1061,7 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
 
         check_firewall_mock._node.get_jobs = lambda: jobs
 
-        assert check_firewall_mock.check_non_finished_jobs() == CheckResult(status=CheckStatus.SUCCESS)
+        assert check_firewall_mock.check_jobs() == CheckResult(status=CheckStatus.SUCCESS)
 
     def test_check_jobs_failure(self, check_firewall_mock):
         jobs = {
@@ -1099,13 +1099,13 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
             },
         }
         check_firewall_mock._node.get_jobs = lambda: jobs
-        result = CheckResult(status=CheckStatus.FAIL, reason="At least one job (ID=4) is not in finished state (state=ACC).")
-        assert check_firewall_mock.check_non_finished_jobs() == result
+        result = CheckResult(status=CheckStatus.FAIL, reason="At least one job (ID=4) does not have a desired status of FIN (status=ACC).")
+        assert check_firewall_mock.check_jobs() == result
 
     def test_check_jobs_no_jobs(self, check_firewall_mock):
         check_firewall_mock._node.get_jobs = lambda: {}
         result = CheckResult(status=CheckStatus.SKIPPED, reason="No jobs found on device. This is unusual, please investigate.")
-        assert check_firewall_mock.check_non_finished_jobs() == result
+        assert check_firewall_mock.check_jobs() == result
 
     def test_run_readiness_checks(self, check_firewall_mock):
         check_firewall_mock._check_method_mapping = {

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -1099,7 +1099,9 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
             },
         }
         check_firewall_mock._node.get_jobs = lambda: jobs
-        result = CheckResult(status=CheckStatus.FAIL, reason="At least one job (ID=4) does not have a desired status of FIN (status=ACC).")
+        result = CheckResult(
+            status=CheckStatus.FAIL, reason="At least one job (ID=4) does not have a desired status of FIN (status=ACC)."
+        )
         assert check_firewall_mock.check_jobs() == result
 
     def test_check_jobs_no_jobs(self, check_firewall_mock):


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
I modified the method `check_non_finished_jobs` in `CheckFirewall` class and renamed it to `check_jobs`. Now it allows to pass some parameters (`job_type`, `job_status`, `job_result`) to the method and now we can query any of those 3 keys values. 

So we can not only check whether the **status** is `FIN` but also if the **type** is `Commit` or the **result** is `OK` (or any different combination). Default parameters check only for **status** of `FIN`, so method's default behaviour remains the same.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#161 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests within the repo.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
