### PR TITLE
fix: get_jobs exception when single job entry

### DIFF
--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1393,7 +1393,7 @@ class FirewallProxy:
         jobs = self.op_parser(cmd="show jobs all")
         results = dict()
 
-        job_results = jobs.get("job")
+        job_results = jobs.get("job") if isinstance(jobs, dict) else None
         if isinstance(job_results, list):
             for job in job_results:
                 jid = job["id"]

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1393,11 +1393,16 @@ class FirewallProxy:
         jobs = self.op_parser(cmd="show jobs all")
         results = dict()
 
-        if jobs:
-            for job in jobs["job"]:
+        job_results = jobs.get("job")
+        if isinstance(job_results, list):
+            for job in job_results:
                 jid = job["id"]
                 job.pop("id")
                 results[jid] = job
+        elif isinstance(job_results, dict):  # single job entry - FW just started up
+            jid = job_results["id"]
+            job_results.pop("id")
+            results[jid] = job_results
 
         return results
 

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1429,6 +1429,56 @@ class TestFirewallProxy:
             },
         }
 
+    def test_get_jobs_single_job(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <job>
+                    <tenq>2023/08/07 03:59:57</tenq>
+                    <tdeq>03:59:57</tdeq>
+                    <id>1</id>
+                    <user/>
+                    <type>AutoCom</type>
+                    <status>FIN</status>
+                    <queued>NO</queued>
+                    <stoppable>no</stoppable>
+                    <result>OK</result>
+                    <tfin>2023/08/07 04:00:28</tfin>
+                    <description/>
+                    <positionInQ>0</positionInQ>
+                    <progress>100</progress>
+                    <details>
+                        <line>Configuration committed successfully</line>
+                        <line>Successfully committed last configuration</line>
+                    </details>
+                    <warnings/>
+                </job>
+            </result>
+        </response>
+        """
+
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_jobs() == {
+            "1": {
+                "tenq": "2023/08/07 03:59:57",
+                "tdeq": "03:59:57",
+                "user": None,
+                "type": "AutoCom",
+                "status": "FIN",
+                "queued": "NO",
+                "stoppable": "no",
+                "result": "OK",
+                "tfin": "2023/08/07 04:00:28",
+                "description": None,
+                "positionInQ": "0",
+                "progress": "100",
+                "details": {"line": ["Configuration committed successfully", "Successfully committed last configuration"]},
+                "warnings": None,
+            },
+        }
+
     def test_get_jobs_no_jobs(self, fw_proxy_mock):
         xml_text = """
         <response status="success">


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixes `FirewallProxy.get_jobs()` method to handle jobs response with a single entry as dict (instead of list).

See #164 for details.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #164 and #124 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on firewalls with example scripts.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
