### PR TITLE
fix: Failing snapshots of FWs with no BGP peers

### DIFF
--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -704,7 +704,7 @@ class FirewallProxy:
 
         if "entry" in response:
             bgp_peers = response["entry"]
-            for peer in bgp_peers if isinstance(bgp_peers, list) else [bgp_peers]:
+            for peer in (bgp_peers if isinstance(bgp_peers, list) else [bgp_peers]):
                 result[
                     f"{peer['@vr'].replace(' ', '-')}_{peer['peer-group'].replace(' ', '-')}_{peer['@peer'].replace(' ', '-')}"
                 ] = dict(peer)

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -699,7 +699,7 @@ class FirewallProxy:
 
         result = {}
 
-        if response == None:
+        if response is None:
             return result
 
         if "entry" in response:

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -704,7 +704,7 @@ class FirewallProxy:
 
         if "entry" in response:
             bgp_peers = response["entry"]
-            for peer in (bgp_peers if isinstance(bgp_peers, list) else [bgp_peers]):
+            for peer in bgp_peers if isinstance(bgp_peers, list) else [bgp_peers]:
                 result[
                     f"{peer['@vr'].replace(' ', '-')}_{peer['peer-group'].replace(' ', '-')}_{peer['@peer'].replace(' ', '-')}"
                 ] = dict(peer)

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -698,6 +698,10 @@ class FirewallProxy:
         response = self.op_parser(cmd="show routing protocol bgp peer")
 
         result = {}
+
+        if response == None:
+            return result
+
         if "entry" in response:
             bgp_peers = response["entry"]
             for peer in bgp_peers if isinstance(bgp_peers, list) else [bgp_peers]:

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -700,6 +700,17 @@ class TestFirewallProxy:
             }
         }
 
+    def test_get_bgp_peers_no_peers(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result/>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_bgp_peers() == {}
+
     def test_get_arp_table(self, fw_proxy_mock):
         xml_text = """
         <response status="success">


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Release v0.3.4 introduced BGP peers information to snapshots. Function didn't handle well a situation where the firewalls didn't have any BGP peers. Added additional _if statement_ to handle that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As above.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with examples present in the repo.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
