### PR TITLE
fix: typing-extensions dependency missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pan-python = "^0.17"
 xmltodict = "^0.12"
 pyopenssl = "^23.2"
 packaging = ">=22.0"
-typing-extensions = ">=4.12.2"
+typing-extensions = "4.6.3"
 
 [tool.poetry.group.dev.dependencies]
 pydoc-markdown = "^4.6"
@@ -35,6 +35,8 @@ flake8-pyproject = "^1.2"
 pytest = "^7.2.1"
 pytest-cov = "^4.0.0"
 deepdiff = "^6.3.0"
+databind-core = "4.4.2"
+databind-json = "4.4.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pan-python = "^0.17"
 xmltodict = "^0.12"
 pyopenssl = "^23.2"
 packaging = ">=22.0"
+typing-extensions = ">=4.12.2"
 
 [tool.poetry.group.dev.dependencies]
 pydoc-markdown = "^4.6"


### PR DESCRIPTION
## Description

Missing dependency in pyproject.toml causing panos_upgrade_assurance module not found error.


## Motivation and Context

This is a critical issue which makes panos_upgrade_assurance fail to run.

Had to fix it to a specific version "4.6.3", otherwise it breaks pydoc-markdown which have conflicting dependencies. We need to take care of this with #171 

```python
Error: [Traceback (most recent call last):
   
   File "<string>", line 7, in <module>
   File "/usr/local/lib/python3.10/site-packages/panos_upgrade_assurance/firewall_proxy.py", line 3, in <module>
    from panos_upgrade_assurance.utils import interpret_yes_no
   File "/usr/local/lib/python3.10/site-packages/panos_upgrade_assurance/utils.py", line 5, in <module>
    from typing_extensions import TypeAlias
 ModuleNotFoundError: No module named 'typing_extensions'
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested manually with example scripts.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
