### PR TITLE
feat: ipsec_tunnel_status check Proxy ID support

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -330,7 +330,9 @@ __Returns__
 
 ```python
 def check_ipsec_tunnel_status(
-        tunnel_name: Optional[str] = None) -> CheckResult
+        tunnel_name: Optional[str] = None,
+        proxy_ids: Optional[List[str]] = None,
+        require_all_active: Optional[bool] = False) -> CheckResult
 ```
 
 Check if a given IPSec tunnel is in active state.
@@ -339,6 +341,9 @@ __Parameters__
 
 
 - __tunnel_name__ (`str, optional`): (defaults to `None`) Name of the searched IPSec tunnel.
+- __proxy_ids__ (`list(str), optional`): (defaults to `None`) ProxyID names to check. All ProxyIDs are checked if None provided.
+- __require_all_active__ (`bool, optional`): (defaults to `False`) If set, all ProxyIDs should be in `active` state. States are
+    checked only within `proxy_ids` if provided.
 
 __Returns__
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds support for Proxy IDs to `ipsec_tunnel_status` readiness check.
`ipsec_tunnel_status` check now accepts a list of `proxy_ids` to check tunnel status against the provided list, or it checks for all configured Proxy IDs if not provided.
By default it will return success if any Proxy ID is in active state for the ipsec tunnel or `require_all_active` flag can be set to require all Proxy IDs to be in active state.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ipsec_tunnel_status` readiness check didn't work if IPSec tunnel was configured with Proxy IDs.
With this enhancement it checks for all the proxy ids for the given tunnel name and returns success if any is in active state. It is also possible to provide a list of proxy ids to limit the check on specific Proxy IDs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the written unittests.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
