### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/workflows/_discover_python_ver.yml
+++ b/.github/workflows/_discover_python_ver.yml
@@ -22,7 +22,7 @@ jobs:
       pyversion: ${{ steps.pyversion.outputs.pyversion }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: discover Python version
         id: pyversion
         uses: ./.github/actions/discover_python_version

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: get the tag name for new image
         id: tag

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ inputs.tag_name }}
 
       - name: install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -30,17 +30,17 @@ jobs:
     #   contents: read
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: get the tag name for new image
         id: tag
@@ -56,7 +56,7 @@ jobs:
 
       - name: determine docker tags and labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           images: ghcr.io/paloaltonetworks/panos_upgrade_assurance
           tags: |
@@ -67,14 +67,14 @@ jobs:
 
       - name: login to GHCR
         if: inputs.publish
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build ${{ inputs.publish && 'and publish' || '' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: ${{ inputs.publish }}

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
           echo ${{ github.event.pull_request.head.ref }} > ./pr/HEAD_REF
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr
           path: pr/

--- a/.github/workflows/close_pr_workflow_run.yml
+++ b/.github/workflows/close_pr_workflow_run.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: download PR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
           name: pr
           path: pr
@@ -39,7 +39,7 @@ jobs:
           echo "pr_number=$(cat NR)" >> "$GITHUB_OUTPUT"
           echo "pr_head_ref=$(cat HEAD_REF)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           result-encoding: string
           github-token: ${{ secrets.CLSC_PAT }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: pack the documentation
         working-directory: docs
         run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
@@ -83,7 +83,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
           echo ${{ github.event.pull_request.head.ref }} > ./pr/HEAD_REF
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr
           path: pr/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: docs
         run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
       - name: upload the documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: documentation
           path: docs/documentation.tar

--- a/.github/workflows/pr_workflow_run.yml
+++ b/.github/workflows/pr_workflow_run.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: post coverage comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@57fcc5cd0dc3e5e78df0d7acd857dd1eed0378c1 # v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -63,13 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout pan.dev
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: PaloAltoNetworks/pan.dev
           token: ${{ secrets.CLSC_PAT }}
 
       - name: download documentation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
           name: documentation
           path: products/panos/docs
@@ -85,7 +85,7 @@ jobs:
 
       - name: create a PR to upstream pan.dev
         id: pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.CLSC_PAT }}
           delete-branch: true
@@ -103,7 +103,7 @@ jobs:
             New feature (non-breaking change which adds functionality)
 
       - name: find if we have a comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2
         id: find
         with:
           issue-number: ${{ needs.pr_status.outputs.pr_number }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: comment back on the original PR
         if: steps.find.outputs.comment-id == '' &&  steps.pr.outputs.pull-request-url != ''
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           issue-number: ${{ needs.pr_status.outputs.pr_number }}
           repository: ${{ github.repository }}

--- a/.github/workflows/pr_workflow_run.yml
+++ b/.github/workflows/pr_workflow_run.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: download PR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
           name: pr
           path: pr

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: pack the documentation
         working-directory: docs
         run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: cleanup old PRs
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           result-encoding: string
           github-token: ${{ secrets.CLSC_PAT }}
@@ -57,7 +57,7 @@ jobs:
         working-directory: docs
         run: tar --exclude .DS_Store --exclude sidebars.js -cvf documentation.tar *
       - name: upload the documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: documentation
           path: docs/documentation.tar
@@ -73,13 +73,13 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout pan.dev
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: PaloAltoNetworks/pan.dev
           token: ${{ secrets.CLSC_PAT }}
 
       - name: download documentation artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: documentation
           path: products/panos/docs
@@ -93,7 +93,7 @@ jobs:
 
       - name: create a PR to upstream pan.dev
         id: pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.CLSC_PAT }}
           delete-branch: true

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: Create Poetry venv 
         run: |

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -19,15 +19,15 @@ jobs:
     needs: pyversion
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ needs.pyversion.outputs.pyversion }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: Create Poetry venv 
         run: |

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ needs.pyversion.outputs.pyversion }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       ver: ${{ steps.rc.outputs.new_release_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Check if new version will be produced
         id: rc
@@ -88,12 +88,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ needs.pyversion.outputs.pyversion }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: Create Poetry venv 
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check if new version will be produced
         id: rc
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           dry_run: true
           semantic_version: 19.0
@@ -85,7 +85,7 @@ jobs:
       tag: ${{ steps.release.outputs.new_release_git_tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create release and publish to GitHub
         id: release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           semantic_version: 19.0
           extra_plugins: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: Create Poetry venv 
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ needs.pyversion.outputs.pyversion }}
 

--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: Create Poetry venv
         run: | 

--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: Create Poetry venv
         run: | 

--- a/.github/workflows/sub_format.yml
+++ b/.github/workflows/sub_format.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/sub_format.yml
+++ b/.github/workflows/sub_format.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: Create Poetry venv
         run: |

--- a/.github/workflows/sub_format.yml
+++ b/.github/workflows/sub_format.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: Create Poetry venv
         run: |

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: "1.8.5"
 
       - name: Create Poetry venv
         run: |

--- a/.github/workflows/sub_unittest.yml
+++ b/.github/workflows/sub_unittest.yml
@@ -27,15 +27,15 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
       - name: Create Poetry venv
         run: |
@@ -48,13 +48,13 @@ jobs:
       # coverage results comment is uploaded to artifact to be written by post PR workflow run
       - name: Coverage comment
         id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@57fcc5cd0dc3e5e78df0d7acd857dd1eed0378c1 # v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
         if: ${{ github.event_name == 'pull_request' }}
 
       - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: |
           ${{ github.event_name == 'pull_request' &&
           steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' }}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions