### PR TITLE
fix: get_jobs with missing job id entries

### DIFF
--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -1170,6 +1170,10 @@ This method retrieves all jobs and their details, this means running, pending, f
 
 The actual API command is `show jobs all`.
 
+:::caution
+Job entries without a jod id is not returned in response. This is usually a 'Failed-Job' type of jobs.
+:::
+
 __Returns__
 
 

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1338,6 +1338,10 @@ class FirewallProxy:
 
         The actual API command is `show jobs all`.
 
+        :::caution
+        Job entries without a jod id is not returned in response. This is usually a 'Failed-Job' type of jobs.
+        :::
+
         # Returns
 
         dict: All jobs found on the device, indexed by the ID of a job.
@@ -1400,13 +1404,16 @@ class FirewallProxy:
         job_results = jobs.get("job") if isinstance(jobs, dict) else None
         if isinstance(job_results, list):
             for job in job_results:
-                jid = job["id"]
+                jid = job.get("id")
+                if jid is None:
+                    continue
                 job.pop("id")
                 results[jid] = job
         elif isinstance(job_results, dict):  # single job entry - FW just started up
-            jid = job_results["id"]
-            job_results.pop("id")
-            results[jid] = job_results
+            jid = job_results.get("id")
+            if jid is not None:
+                job_results.pop("id")
+                results[jid] = job_results
 
         return results
 

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1480,6 +1480,99 @@ class TestFirewallProxy:
             },
         }
 
+    def test_get_jobs_skip_nojobid(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <job>
+                    <tenq>2023/08/07 04:00:40</tenq>
+                    <tdeq>04:00:40</tdeq>
+                    <id>4</id>
+                    <user>Auto update agent</user>
+                    <type>WildFire</type>
+                    <status>FIN</status>
+                    <queued>NO</queued>
+                    <stoppable>no</stoppable>
+                    <result>OK</result>
+                    <tfin>2023/08/07 04:00:45</tfin>
+                    <description/>
+                    <positionInQ>0</positionInQ>
+                    <progress>2023/08/07 04:00:45</progress>
+                    <details>
+                        <line>Configuration committed successfully</line>
+                        <line>Successfully committed last configuration</line>
+                    </details>
+                    <warnings/>
+                </job>
+                <job>
+                    <type>Failed-Job</type>
+                    <details>
+                        <line>job failed because of configd restart</line>
+                    </details>
+                    <warnings />
+                </job>
+                <job>
+                    <tenq>2023/08/07 03:59:57</tenq>
+                    <tdeq>03:59:57</tdeq>
+                    <id>1</id>
+                    <user/>
+                    <type>AutoCom</type>
+                    <status>FIN</status>
+                    <queued>NO</queued>
+                    <stoppable>no</stoppable>
+                    <result>OK</result>
+                    <tfin>2023/08/07 04:00:28</tfin>
+                    <description/>
+                    <positionInQ>0</positionInQ>
+                    <progress>100</progress>
+                    <details>
+                        <line>Configuration committed successfully</line>
+                        <line>Successfully committed last configuration</line>
+                    </details>
+                    <warnings/>
+                </job>
+            </result>
+        </response>
+        """
+
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_jobs() == {
+            "4": {
+                "tenq": "2023/08/07 04:00:40",
+                "tdeq": "04:00:40",
+                "user": "Auto update agent",
+                "type": "WildFire",
+                "status": "FIN",
+                "queued": "NO",
+                "stoppable": "no",
+                "result": "OK",
+                "tfin": "2023/08/07 04:00:45",
+                "description": None,
+                "positionInQ": "0",
+                "progress": "2023/08/07 04:00:45",
+                "details": {"line": ["Configuration committed successfully", "Successfully committed last configuration"]},
+                "warnings": None,
+            },
+            "1": {
+                "tenq": "2023/08/07 03:59:57",
+                "tdeq": "03:59:57",
+                "user": None,
+                "type": "AutoCom",
+                "status": "FIN",
+                "queued": "NO",
+                "stoppable": "no",
+                "result": "OK",
+                "tfin": "2023/08/07 04:00:28",
+                "description": None,
+                "positionInQ": "0",
+                "progress": "100",
+                "details": {"line": ["Configuration committed successfully", "Successfully committed last configuration"]},
+                "warnings": None,
+            },
+        }
+
     def test_get_jobs_single_job(self, fw_proxy_mock):
         xml_text = """
         <response status="success">
@@ -1529,6 +1622,26 @@ class TestFirewallProxy:
                 "warnings": None,
             },
         }
+
+    def test_get_jobs_single_skip_nojobid(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <job>
+                    <type>Failed-Job</type>
+                    <details>
+                        <line>job failed because of configd restart</line>
+                    </details>
+                    <warnings />
+                </job>
+            </result>
+        </response>
+        """
+
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_jobs() == {}
 
     def test_get_jobs_no_jobs(self, fw_proxy_mock):
         xml_text = """


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixes KeyError exception thrown if job entry doesnot have an id for jobs check, typically for Failed-Job type. 
Response doesnot include jobs with no job id now.

## How Has This Been Tested?

Tested with unit tests.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
