### PR TITLE
fix: loosen deps constraints and remove pydoc-markdown

### DIFF
--- a/.github/actions/discover_python_version/action.yml
+++ b/.github/actions/discover_python_version/action.yml
@@ -1,6 +1,11 @@
 name: Discover minimum Python version
 description: Discover the lowest supported Python version based on pyptoject.toml file
 
+inputs:
+  working-directory:
+    required: false
+    default: "./"
+
 outputs:
   pyversion:
     description: Lowest supported python version
@@ -14,12 +19,13 @@ runs:
       shell: bash
       run: |
         # try to extract the 'python = "xxx"' string from TOML file
-        # this script will fail in following situations:
-        #  - the file is not there
-        #  - the string is not there, so no pattern for Python is provided
-        #  - version is not readable - this is handled by '/python/q1' SED command,
-        #    when the regex does not match SED won't do anything and it will return the
-        #    full string, this command looks for 'python' and returns exit code 1 if it finds one
+        CONSTRAINT=$(grep -E '^python\s*=' pyproject.toml | cut -d= -f2- | tr -d ' "')
 
-        PYVER=$(grep '^[Pp]ython ' pyproject.toml | sed -E 's/python += +\"\^?([0-9]\.[0-9]+)(\.[0-9]+)?\"/\1/; /python/q1')
-        echo "pyver=$PYVER" >> $GITHUB_OUTPUT
+        if [[ $CONSTRAINT =~ (>=|\^|~)([0-9]+\.[0-9]+) ]]; then
+            # echo "Operator: ${BASH_REMATCH[1]}"
+            echo "pyver=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+        else
+            echo "No valid Python version found."
+            return 1
+        fi
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Install documentation dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
           pip install -r requirements-docs.txt
 
       - name: Generate API docs

--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -12,6 +12,10 @@ on:
         type: string
         required: true
 
+env:
+  PYTHON_VERSION: "3.8.16"      # TODO fixed python version until we find a replacement for pydoc-markdown
+  # PYTHON_VERSION: ${{ inputs.python_version }}
+
 jobs:
 
   documentation:
@@ -24,28 +28,36 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Poetry
-        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
-        with:
-          poetry-version: "1.8.5"
+      # - name: Install Poetry
+      #   uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+      #   with:
+      #     poetry-version: "1.8.5"
 
-      - name: Create Poetry venv
-        env:
-          PYTHON_VERSION: '${{ inputs.python_version }}'
-        run: | 
-          poetry env use $PYTHON_VERSION
-          poetry install
+      # - name: Create Poetry venv
+      #   run: | 
+      #     poetry env use $PYTHON_VERSION
+      #     poetry install
+
+      # - name: Generate API docs
+      #   run: poetry run make documentation
+
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
 
       - name: Generate API docs
-        run: poetry run make documentation
+        run: make documentation
 
       - name: Check if documentation needs updating
         run: |
           if [ "$(git status --porcelain)" ]; then 
             git status
+            echo "Documentation changes detected. Please update the documentation and commit the changes."
             exit 1
           else
+            echo "No documentation changes detected."
             exit 0
           fi

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lint:
 
 .phony: security
 security:
-	bandit -c pyproject.toml -r .
+	bandit -c pyproject.toml -r panos_upgrade_assurance tests
 
 .phony: format_check
 format_check:
@@ -37,7 +37,7 @@ check_line_length:
 	done
 
 .phony: all
-all: lint format security test_coverage documentation
+all: lint format security test_coverage
 
 .phony: sca
 sca: format lint security

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -488,8 +488,6 @@ def interpret_yes_no(boolstr: str) -> bool:
 def printer(report: dict, indent_level: int = 0) -> None:  # pragma: no cover - exclude from pytest coverage
     """Print reports in human friendly format.
 
-    Some desc to trigger doc update CI..
-
     # Parameters
 
     report (dict): Dict with reports from tests.

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -488,6 +488,8 @@ def interpret_yes_no(boolstr: str) -> bool:
 def printer(report: dict, indent_level: int = 0) -> None:  # pragma: no cover - exclude from pytest coverage
     """Print reports in human friendly format.
 
+    Some desc to trigger doc update CI..
+
     # Parameters
 
     report (dict): Dict with reports from tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,25 +18,20 @@ classifiers = [
 "Bug Tracker" = "https://github.com/PaloAltoNetworks/pan-os-upgrade-assurance/issues"
 
 [tool.poetry.dependencies]
-python = "^3.8"
-pan-os-python = "^1.8"
-pan-python = "^0.17"
-xmltodict = "^0.12"
-pyopenssl = "^23.2"
+python = ">=3.8"
+pan-os-python = ">=1.8,<2.0"
+xmltodict = ">=0.12.0,<0.15.0"
+pyopenssl = ">=23.2,<24.0"
 packaging = ">=22.0"
-typing-extensions = "4.6.3"
 
 [tool.poetry.group.dev.dependencies]
-pydoc-markdown = "^4.6"
-flake8 = "^5"
-black = "23.11"
-bandit = "^1.7"
-flake8-pyproject = "^1.2"
-pytest = "^7.2.1"
-pytest-cov = "^4.0.0"
-deepdiff = "^6.3.0"
-databind-core = "4.4.2"
-databind-json = "4.4.2"
+flake8 = ">=5"
+black = ">=23.11"
+bandit = ">=1.7"
+flake8-pyproject = ">=1.2"
+pytest = ">=7.2.1"
+pytest-cov = ">=4.0.0"
+deepdiff = ">=6.3.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+pydoc-markdown

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,1 @@
 pydoc-markdown
-setuptools

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,2 @@
 pydoc-markdown
+setuptools


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
* converted depedency version contraints to >=,<
* removed pydoc-markdown dependency temporarily until we find a better approach - it restricts dependency updates since its not being maintained anymore 
* removed fixed version typing_extensions and databind deps

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Temp remediation for #171 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
pytest

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- deps

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
