### PR TITLE
fix: Bump Dockerfile python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.11
 
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.12
 
 
 WORKDIR /


### PR DESCRIPTION
## Description

Users reported the upgrade assurance docker image is failing to run within XSOAR with `ModuleNotFoundError: No module named 'typing_extensions'` 

![image](https://github.com/user-attachments/assets/8b41eabd-76e6-46ae-951d-47724046f2a1)


The docker image is currently set to `3.10` but `TypeAlias` is implemented in 3.12, so I think we need to bump it.