### PR TITLE
feat: global jumbo frame snapshot and readiness check

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -554,6 +554,30 @@ __Returns__
 * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when there are no jobs on a
     device.
 
+### `CheckFirewall.check_global_jumbo_frame`
+
+```python
+def check_global_jumbo_frame(mode: bool = None) -> CheckResult
+```
+
+Check if the global jumbo frame configuration matches the desired mode.
+
+__Parameters__
+
+
+- __mode__ (`bool`): The desired mode of the global jumbo frame configuration.
+
+__Returns__
+
+
+`CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
+
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the global jumbo frame
+    mode matches the desired mode.
+* [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the current global jumbo
+    frame and the desired modes differ.
+* [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when `mode` is not provided.
+
 ### `CheckFirewall.get_content_db_version`
 
 ```python
@@ -600,6 +624,25 @@ __Returns__
         "owner": "1",
         "id": "1"
     }
+}
+```
+
+### `CheckFirewall.get_global_jumbo_frame`
+
+```python
+def get_global_jumbo_frame() -> Dict[str, bool]
+```
+
+Get whether global jumbo frame configuration is set or not.
+
+__Returns__
+
+
+`dict`: The global jumbo frame configuration.
+
+```python showLineNumbers title="Example"
+{
+    'mode': True
 }
 ```
 

--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -234,6 +234,21 @@ __Returns__
 
 `bool`: `True` when connection is up, `False` otherwise.
 
+### `FirewallProxy.is_global_jumbo_frame_set`
+
+```python
+def is_global_jumbo_frame_set() -> bool
+```
+
+Get the global jumbo frame configuration.
+
+The actual API command is `show system setting jumbo-frame`.
+
+__Returns__
+
+
+`bool`: `True` when global jumbo frame configuration is on, `False` otherwise.
+
 ### `FirewallProxy.get_ha_configuration`
 
 ```python

--- a/docs/panos-upgrade-assurance/api/utils.md
+++ b/docs/panos-upgrade-assurance/api/utils.md
@@ -378,22 +378,22 @@ __Returns__
 def interpret_yes_no(boolstr: str) -> bool
 ```
 
-Interpret `yes`/`no` as booleans.
+Interpret `yes`/`no` and `on`/`off` as booleans.
 
 __Parameters__
 
 
-- __boolstr__ (`str`): `yes` or `no`, a typical device response for simple boolean-like queries.
+- __boolstr__ (`str`): `yes`, `no`, `on` or `off`, a typical device response for simple boolean-like queries.
 
 __Raises__
 
 
-- `WrongDataTypeException`: An exception is raised when `boolstr` is neither `yes` or `no`.
+- `WrongDataTypeException`: An exception is raised when `boolstr` is neither `yes`, `no`, `on` or `off`.
 
 __Returns__
 
 
-`bool`: `True` for *yes*, `False` for *no*.
+`bool`: `True` for *yes* / *on*, `False` otherwise.
 
 ### `printer`
 

--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -113,6 +113,7 @@ if __name__ == "__main__":
         },
         {"arp_entry_exist": {"ip": "10.0.1.1"}},
         {"ip_sec_tunnel_status": {"tunnel_name": "ipsec_tun"}},
+        {"global_jumbo_frame": {"mode": True}},
     ]
 
     check_readiness = check_node.run_readiness_checks(

--- a/examples/readiness_checks/run_readiness_snapshot.py
+++ b/examples/readiness_checks/run_readiness_snapshot.py
@@ -89,6 +89,7 @@ if __name__ == "__main__":
         "content_version",
         "session_stats",
         "ip_sec_tunnels",
+        "global_jumbo_frame",
     ]
 
     snap = check_node.run_snapshots(snapshots_config=areas)

--- a/examples/report/fw1.snapshot
+++ b/examples/report/fw1.snapshot
@@ -1,4 +1,7 @@
 {
+  "global_jumbo_frame": {
+    "mode": true
+  },
   "ip_sec_tunnels": {
     "ipsec_tun": {
       "peerip": "10.26.129.5",

--- a/examples/report/fw2.snapshot
+++ b/examples/report/fw2.snapshot
@@ -1,4 +1,7 @@
 {
+  "global_jumbo_frame": {
+    "mode": false
+  },
   "ip_sec_tunnels": {
     "ipsec_tun": {
       "peerip": "10.26.129.5",

--- a/examples/report/snapshot_load_compare.py
+++ b/examples/report/snapshot_load_compare.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
                 ]
             }
         },
+        "global_jumbo_frame",
     ]
 
     compare = SnapshotCompare(

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -1134,12 +1134,11 @@ class CheckFirewall:
         CheckResult: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking \
             value of:
 
-        * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the global jumbo frame \
+        * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the global jumbo frame
             mode matches the desired mode.
-        * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the current global jumbo \
+        * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the current global jumbo
             frame and the desired modes differ.
-        * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when `mode` is not
-            provided.
+        * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when `mode` is not provided.
 
         """
         result = CheckResult()

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -263,6 +263,19 @@ class FirewallProxy:
                 f"Panorama configuration block does not have typical structure: <{pan_status}>."
             )
 
+    def is_global_jumbo_frame_set(self) -> bool:
+        """Get the global jumbo frame configuration.
+
+        The actual API command is `show system setting jumbo-frame`.
+
+        # Returns
+
+        bool: `True` when global jumbo frame configuration is on, `False` otherwise.
+
+        """
+        response = self.op_parser(cmd="show system setting jumbo-frame")
+        return interpret_yes_no(response.strip())
+
     def get_ha_configuration(self) -> dict:
         """Get high-availability configuration status.
 

--- a/panos_upgrade_assurance/snapshot_compare.py
+++ b/panos_upgrade_assurance/snapshot_compare.py
@@ -67,6 +67,7 @@ class SnapshotCompare:
             SnapType.SESSION_STATS: self.get_count_change_percentage,
             SnapType.IPSEC_TUNNELS: self.get_diff_and_threshold,
             SnapType.FIB_ROUTES: self.get_diff_and_threshold,
+            SnapType.GLOBAL_JUMBO_FRAME: self.get_diff_and_threshold,
         }
 
     def compare_snapshots(self, reports: Optional[List[Union[dict, str]]] = None) -> Dict[str, dict]:

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -32,6 +32,7 @@ class CheckType:
     CERTS = "certificates_requirements"
     UPDATES = "dynamic_updates"
     JOBS = "jobs"
+    GLOBAL_JUMBO_FRAME = "global_jumbo_frame"
 
 
 class SnapType:
@@ -53,6 +54,7 @@ class SnapType:
     SESSION_STATS = "session_stats"
     IPSEC_TUNNELS = "ip_sec_tunnels"
     FIB_ROUTES = "fib_routes"
+    GLOBAL_JUMBO_FRAME = "global_jumbo_frame"
 
 
 class HealthType:
@@ -464,25 +466,25 @@ class ConfigParser:
 
 
 def interpret_yes_no(boolstr: str) -> bool:
-    """Interpret `yes`/`no` as booleans.
+    """Interpret `yes`/`no` and `on`/`off` as booleans.
 
     # Parameters
 
-    boolstr (str): `yes` or `no`, a typical device response for simple boolean-like queries.
+    boolstr (str): `yes`, `no`, `on` or `off`, a typical device response for simple boolean-like queries.
 
     # Raises
 
-    WrongDataTypeException: An exception is raised when `boolstr` is neither `yes` or `no`.
+    WrongDataTypeException: An exception is raised when `boolstr` is neither `yes`, `no`, `on` or `off`.
 
     # Returns
 
-    bool: `True` for *yes*, `False` for *no*.
+    bool: `True` for *yes* / *on*, `False` otherwise.
 
     """
-    if boolstr not in ["yes", "no"]:
+    if boolstr not in ["yes", "no", "on", "off"]:
         raise exceptions.WrongDataTypeException(f"Cannot interpret following string as boolean: {boolstr}.")
 
-    return True if boolstr == "yes" else False
+    return True if boolstr in ["yes", "on"] else False
 
 
 def printer(report: dict, indent_level: int = 0) -> None:  # pragma: no cover - exclude from pytest coverage

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -242,6 +242,28 @@ class TestFirewallProxy:
         expected = "Panorama configuration block does not have typical structure: <some line : to break code>."
         assert expected in str(exc_info.value)
 
+    def test_is_global_jumbo_frame_set_on(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>on</result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.is_global_jumbo_frame_set()  # == True
+
+    def test_is_global_jumbo_frame_set_off(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>off</result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert not fw_proxy_mock.is_global_jumbo_frame_set()  # == False
+
     def test_get_ha_configuration(self, fw_proxy_mock):
         xml_text = """<response status='success'><result>
         {'enabled': 'yes'}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
adding `global_jumbo_frame` snapshot type and readiness check.
with the `global_jumbo_frame` snapshot it is possible to compare global jumbo frame configuration pre and post upgrade.
And the readiness check allows to check if global jumbo frame configuration is in the expected mode which gets `mode: True` or `mode: False` attribute as an input.

## How Has This Been Tested?

Tested with local scripts and local ansible playbook
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
