### PR TITLE
feat: system environmentals readiness check

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -578,6 +578,33 @@ __Returns__
     frame and the desired modes differ.
 * [`CheckStatus.SKIPPED`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when `mode` is not provided.
 
+### `CheckFirewall.check_system_environmentals`
+
+```python
+def check_system_environmentals(
+        components: Optional[List[str]] = None) -> CheckResult
+```
+
+Check system environmentals for alarms.
+
+__Parameters__
+
+
+- __components__ (`list(str), optional`): (defaults to None) List of components to check for alarms.
+    If None, all components are checked. Valid components are 'thermal', 'fantray', 'fan', 'power', 'power-supply'.
+
+__Returns__
+
+
+`CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
+
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) if no alarms are found in the
+    specified components.
+* [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) if any alarm is found in specified
+    components.
+* [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when invalid components are
+    specified or device did not return environmentals.
+
 ### `CheckFirewall.get_content_db_version`
 
 ```python

--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -1394,3 +1394,83 @@ __Returns__
 datetime(2024, 01, 01, 00, 00, 00)
 ```
 
+### `FirewallProxy.get_system_environmentals`
+
+```python
+def get_system_environmentals() -> dict
+```
+
+Get system environmental data.
+
+The actual API command is `show system environmentals`.
+
+__Returns__
+
+
+`dict`: System environmental data including thermal, fantray, fan, power, and power-supply information.
+    Sample output has been shortened for the sake of simplicity.
+
+```python showLineNumbers title="Sample output"
+{'fan': {'Slot1': {'entry': [{'RPMs': '3435',
+                              'alarm': 'False',
+                              'description': 'Fan `1` RPM',
+                              'min': '1000',
+                              'slot': '1'},
+                             {'RPMs': '3379',
+                              'alarm': 'False',
+                              'description': 'Fan `2` RPM',
+                              'min': '1000',
+                              'slot': '1'},
+                             {'RPMs': '3355',
+                              'alarm': 'False',
+                              'description': 'Fan `3` RPM',
+                              'min': '1000',
+                              'slot': '1'}]}},
+ 'fantray': {'Slot1': {'entry': {'Inserted': 'True',
+                                 'alarm': 'False',
+                                 'description': 'Fan Tray',
+                                 'min': '1',
+                                 'slot': '1'}}},
+ 'power': {'Slot1': {'entry': [{'Volts': '1.7939999999999998',
+                                'alarm': 'False',
+                                'description': 'Power: MP - 1.8V VCCIN',
+                                'max': '1.98',
+                                'min': '1.62',
+                                'slot': '1'},
+                               {'Volts': '1.8046666666666666',
+                                'alarm': 'False',
+                                'description': 'Power: DP - 1.8V Power Rail',
+                                'max': '1.98',
+                                'min': '1.62',
+                                'slot': '1'}]}},
+ 'power-supply': {'Slot1': {'entry': [{'Inserted': 'False',
+                                       'alarm': 'True',
+                                       'description': 'Power Supply `1` (left)',
+                                       'min': 'True',
+                                       'slot': '1'},
+                                      {'Inserted': 'True',
+                                       'alarm': 'False',
+                                       'description': 'Power Supply `2` (right)',
+                                       'min': 'True',
+                                       'slot': '1'}]}},
+ 'thermal': {'Slot0': {'entry': {'DegreesC': '29.8',
+                                 'alarm': 'False',
+                                 'description': 'Temperature: Broadwell MP '
+                                                'Core',
+                                 'max': '70.0',
+                                 'min': '-5.0',
+                                 'slot': '0'}},
+             'Slot1': {'entry': [{'DegreesC': '36.5',
+                                  'alarm': 'False',
+                                  'description': 'Temperature @ Rear Left[U54]',
+                                  'max': '70.0',
+                                  'min': '-5.0',
+                                  'slot': '1'},
+                                 {'DegreesC': '46.2',
+                                  'alarm': 'False',
+                                  'description': 'Temperature: FE100 Core',
+                                  'max': '70.0',
+                                  'min': '-5.0',
+                                  'slot': '1'}]}}}
+```
+

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -622,6 +622,54 @@ checks_configuration:
 ```
 
 
+### `environmentals`
+
+This check examines the system environmentals for any alarms. It can be configured to check specific components or all components if none are specified.
+
+**Method:** [`CheckFirewall.check_system_environmentals()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_system_environmentals)
+
+**Configuration parameters**
+
+parameter | description
+--- | ---
+`components` | (optional) List of components to check for alarms. If not provided, all components are checked. Valid components are: 'thermal', 'fantray', 'fan', 'power', 'power-supply'.
+
+**Sample configuration**
+
+```mdx-code-block
+<Tabs>
+<TabItem value="python" label="Python" default>
+```
+
+```python showLineNumbers
+checks_configuration = [
+    { 
+        'environmentals': {
+            'components': ['thermal', 'power']
+        }
+    }
+]
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="ansible" label="YAML">
+```
+
+```yaml showLineNumbers
+checks_configuration:
+  - environmentals:
+      components:
+        - thermal
+        - power
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+
 ### `expired_licenses`
 
 Checks and reports expired licenses.

--- a/examples/low_level_methods/run_low_level_methods.py
+++ b/examples/low_level_methods/run_low_level_methods.py
@@ -124,5 +124,6 @@ if __name__ == "__main__":
 
     print(f"\n  jobs: {firewall.get_jobs()}")
 
+    print(f"\n  system environmentals: {firewall.get_system_environmentals()}")
 
     print()

--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
             }
         },
         {"dynamic_updates": {"test_window": 500}},
+        {"environmentals": {"components": ["power-supply"]}},
         # checks below require additional configuration
         {
             "session_exist": {

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -1163,7 +1163,7 @@ class CheckFirewall:
         # Parameters
 
         components (list(str), optional): (defaults to None) List of components to check for alarms.
-            If None, all components are checked. Valid components are: 'thermal', 'fantray', 'fan', 'power', 'power-supply'.
+            If None, all components are checked. Valid components are 'thermal', 'fantray', 'fan', 'power', 'power-supply'.
 
         # Returns
 

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1635,7 +1635,7 @@ class FirewallProxy:
         # Returns
 
         dict: System environmental data including thermal, fantray, fan, power, and power-supply information.
-            Sample output has been shortened for the sake of clarity.
+            Sample output has been shortened for the sake of simplicity.
 
         ```python showLineNumbers title="Sample output"
         {'fan': {'Slot1': {'entry': [{'RPMs': '3435',

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1626,3 +1626,82 @@ class FirewallProxy:
         )
 
         return rebooted_time
+
+    def get_system_environmentals(self) -> dict:
+        """Get system environmental data.
+
+        The actual API command is `show system environmentals`.
+
+        # Returns
+
+        dict: System environmental data including thermal, fantray, fan, power, and power-supply information.
+            Sample output has been shortened for the sake of clarity.
+
+        ```python showLineNumbers title="Sample output"
+        {'fan': {'Slot1': {'entry': [{'RPMs': '3435',
+                                      'alarm': 'False',
+                                      'description': 'Fan #1 RPM',
+                                      'min': '1000',
+                                      'slot': '1'},
+                                     {'RPMs': '3379',
+                                      'alarm': 'False',
+                                      'description': 'Fan #2 RPM',
+                                      'min': '1000',
+                                      'slot': '1'},
+                                     {'RPMs': '3355',
+                                      'alarm': 'False',
+                                      'description': 'Fan #3 RPM',
+                                      'min': '1000',
+                                      'slot': '1'}]}},
+         'fantray': {'Slot1': {'entry': {'Inserted': 'True',
+                                         'alarm': 'False',
+                                         'description': 'Fan Tray',
+                                         'min': '1',
+                                         'slot': '1'}}},
+         'power': {'Slot1': {'entry': [{'Volts': '1.7939999999999998',
+                                        'alarm': 'False',
+                                        'description': 'Power: MP - 1.8V VCCIN',
+                                        'max': '1.98',
+                                        'min': '1.62',
+                                        'slot': '1'},
+                                       {'Volts': '1.8046666666666666',
+                                        'alarm': 'False',
+                                        'description': 'Power: DP - 1.8V Power Rail',
+                                        'max': '1.98',
+                                        'min': '1.62',
+                                        'slot': '1'}]}},
+         'power-supply': {'Slot1': {'entry': [{'Inserted': 'False',
+                                               'alarm': 'True',
+                                               'description': 'Power Supply #1 (left)',
+                                               'min': 'True',
+                                               'slot': '1'},
+                                              {'Inserted': 'True',
+                                               'alarm': 'False',
+                                               'description': 'Power Supply #2 (right)',
+                                               'min': 'True',
+                                               'slot': '1'}]}},
+         'thermal': {'Slot0': {'entry': {'DegreesC': '29.8',
+                                         'alarm': 'False',
+                                         'description': 'Temperature: Broadwell MP '
+                                                        'Core',
+                                         'max': '70.0',
+                                         'min': '-5.0',
+                                         'slot': '0'}},
+                     'Slot1': {'entry': [{'DegreesC': '36.5',
+                                          'alarm': 'False',
+                                          'description': 'Temperature @ Rear Left[U54]',
+                                          'max': '70.0',
+                                          'min': '-5.0',
+                                          'slot': '1'},
+                                         {'DegreesC': '46.2',
+                                          'alarm': 'False',
+                                          'description': 'Temperature: FE100 Core',
+                                          'max': '70.0',
+                                          'min': '-5.0',
+                                          'slot': '1'}]}}}
+        ```
+
+        """
+        response = self.op_parser(cmd="show system environmentals")
+
+        return response if response else {}

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -33,6 +33,7 @@ class CheckType:
     UPDATES = "dynamic_updates"
     JOBS = "jobs"
     GLOBAL_JUMBO_FRAME = "global_jumbo_frame"
+    SYSTEM_ENVIRONMENTALS = "environmentals"
 
 
 class SnapType:

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -2278,3 +2278,124 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert type(fw_proxy_mock.get_system_time_rebooted()) is datetime
+
+    def test_get_system_environmentals(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success"><result>
+          <thermal>
+            <Slot0>
+              <entry>
+                <slot>0</slot>
+                <description>Temperature: Broadwell MP Core</description>
+                <alarm>False</alarm>
+                <DegreesC>29.8</DegreesC>
+                <min>-5.0</min>
+                <max>70.0</max>
+              </entry>
+            </Slot0>
+          </thermal>
+          <fantray>
+            <Slot1>
+              <entry>
+                <slot>1</slot>
+                <description>Fan Tray</description>
+                <alarm>False</alarm>
+                <Inserted>True</Inserted>
+                <min>1</min>
+              </entry>
+            </Slot1>
+          </fantray>
+          <fan>
+            <Slot1>
+              <entry>
+                <slot>1</slot>
+                <description>Fan #1 RPM</description>
+                <alarm>False</alarm>
+                <RPMs>3689</RPMs>
+                <min>1000</min>
+              </entry>
+            </Slot1>
+          </fan>
+          <power>
+            <Slot1>
+              <entry>
+                <slot>1</slot>
+                <description>Power: DP - Switch 1.0V Core</description>
+                <alarm>False</alarm>
+                <Volts>1.008</Volts>
+                <min>0.9</min>
+                <max>1.1</max>
+              </entry>
+            </Slot1>
+          </power>
+          <power-supply>
+            <Slot1>
+              <entry>
+                <slot>1</slot>
+                <description>Power Supply #1 (left)</description>
+                <alarm>True</alarm>
+                <Inserted>False</Inserted>
+                <min>True</min>
+              </entry>
+            </Slot1>
+          </power-supply>
+        </result></response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_system_environmentals() == {
+            "thermal": {
+                "Slot0": {
+                    "entry": {
+                        "slot": "0",
+                        "description": "Temperature: Broadwell MP Core",
+                        "alarm": "False",
+                        "DegreesC": "29.8",
+                        "min": "-5.0",
+                        "max": "70.0",
+                    }
+                }
+            },
+            "fantray": {
+                "Slot1": {"entry": {"slot": "1", "description": "Fan Tray", "alarm": "False", "Inserted": "True", "min": "1"}}
+            },
+            "fan": {
+                "Slot1": {"entry": {"slot": "1", "description": "Fan #1 RPM", "alarm": "False", "RPMs": "3689", "min": "1000"}}
+            },
+            "power": {
+                "Slot1": {
+                    "entry": {
+                        "slot": "1",
+                        "description": "Power: DP - Switch 1.0V Core",
+                        "alarm": "False",
+                        "Volts": "1.008",
+                        "min": "0.9",
+                        "max": "1.1",
+                    }
+                }
+            },
+            "power-supply": {
+                "Slot1": {
+                    "entry": {
+                        "slot": "1",
+                        "description": "Power Supply #1 (left)",
+                        "alarm": "True",
+                        "Inserted": "False",
+                        "min": "True",
+                    }
+                }
+            },
+        }
+
+    def test_get_system_environmentals_empty_response(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_system_environmentals() == {}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
`environmentals` readiness check added to check for any alarms in the `show system environmentals` output. Check optionally accepts "components" to only check alarms in specific components like fan or power-supply.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and on firewalls with ansible playbook.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
