### PR TITLE
feat: data plane and management plane cpu readiness checks

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -605,6 +605,68 @@ __Returns__
 * [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when invalid components are
     specified or device did not return environmentals.
 
+### `CheckFirewall.check_dp_cpu_utilization`
+
+```python
+def check_dp_cpu_utilization(threshold: int = 80,
+                             minutes: int = 5) -> CheckResult
+```
+
+Check if the data plane CPU utilization is below a specified threshold.
+
+This check retrieves the data plane CPU utilization for the specified duration and calculates the average CPU load
+across all cores. If the average CPU load is below the threshold, the check passes.
+
+__Parameters__
+
+
+- __threshold__ (`int, optional`): (defaults to 80) Maximum acceptable average CPU utilization percentage.
+- __minutes__ (`int, optional`): (defaults to 5) Number of minutes to check, between 1 and 60.
+
+__Raises__
+
+
+- `WrongDataTypeException`: Raised when the threshold or minutes parameters are not integers.
+
+__Returns__
+
+
+`CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
+
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when average CPU utilization is below the threshold.
+* [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when average CPU utilization is equal to or above the threshold.
+* [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the data cannot be retrieved.
+
+### `CheckFirewall.check_mp_cpu_utilization`
+
+```python
+def check_mp_cpu_utilization(threshold: int = 80) -> CheckResult
+```
+
+Check if the management plane CPU utilization is below a specified threshold.
+
+This check retrieves the management plane CPU utilization for the last 1 minute and compares it
+against the provided threshold.
+
+__Parameters__
+
+
+- __threshold__ (`int, optional`): (defaults to 80) Maximum acceptable CPU utilization percentage.
+
+__Raises__
+
+
+- `WrongDataTypeException`: Raised when the threshold parameter is not an integer or is outside the allowed range.
+
+__Returns__
+
+
+`CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
+
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when CPU utilization is below the threshold.
+* [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when CPU utilization is equal to or above the threshold.
+* [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the data cannot be retrieved.
+
 ### `CheckFirewall.get_content_db_version`
 
 ```python

--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -1474,3 +1474,64 @@ __Returns__
                                   'slot': '1'}]}}}
 ```
 
+### `FirewallProxy.get_dp_cpu_utilization`
+
+```python
+def get_dp_cpu_utilization(minutes: int = 5) -> dict
+```
+
+Get data plane CPU utilization for the last specified minutes.
+
+The actual API command is `show running resource-monitor minute last {minutes}`.
+
+__Parameters__
+
+
+- __minutes__ (`int, optional`): (defaults to 5) The number of minutes to check, between 1 and 60.
+
+__Raises__
+
+
+- `WrongDataTypeException`: Raised when the minutes parameter is not an integer or is outside the allowed range.
+- `MalformedResponseException`: Raised when response does not contain expected elements.
+
+__Returns__
+
+
+`dict`: Data plane CPU utilization per core and per minute.
+
+```python showLineNumbers title="Sample output"
+{
+    'dp0': {
+        'cpu-load-average': {
+            '0': [0, 0, 0, 0, 0],
+            '1': [0, 0, 0, 0, 0],
+            '2': [1, 1, 1, 1, 1],
+            '3': [0, 0, 0, 0, 0]
+        }
+    }
+}
+```
+
+### `FirewallProxy.get_mp_cpu_utilization`
+
+```python
+def get_mp_cpu_utilization() -> int
+```
+
+Get management plane CPU utilization for the last 1 minute.
+
+The actual API command is `<show><system><state><filter>sys.monitor.*.mp.exports</filter></state></system></show>`.
+MP state resides under s0 or s1 depending on the target firewall platform like `sys.monitor.s0.mp.exports` or
+`sys.monitor.s1.mp.exports` so a wildcard is used to match any.
+
+__Raises__
+
+
+- `MalformedResponseException`: Raised when response does not contain expected elements or data format is invalid.
+
+__Returns__
+
+
+`int`: Management plane CPU utilization percentage for the last 1 minute.
+

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -270,12 +270,13 @@ checks_configuration = [
         }
     },
     {'content_version': {'version': '8634-7678'}},
+    {'dp_cpu_utilization': {'threshold': 50, 'minutes': 2}},
     {'dynamic_updates': {'test_window': 120}},
     {"expired_licenses": {"skip_licenses": ["Threat Prevention"]}},
     {'free_disk_space': {'image_version': '10.1.6-h6'}},
     {'ha': {'skip_config_sync': True}},
+    {'mp_cpu_utilization': {'threshold': 40}},
     {'planes_clock_sync': {'diff_threshold': 30}},
-    {'dp_cpu_utilization': {'threshold': 50, 'minutes': 2}},
     # tests below require additional configuration
     {'arp_entry_exist': {'ip': '10.0.1.1'} },
     {'ip_sec_tunnel_status': {
@@ -311,6 +312,9 @@ checks_configuration:
         hash_method: "sha1"
   - content_version:
       version: "8634-7678"
+  - dp_cpu_utilization:
+      threshold: 50
+      minutes: 2
   - dynamic_updates:
       test_window: 120
   - expired_licenses:
@@ -320,11 +324,10 @@ checks_configuration:
       image_version: "10.1.6-h6"
   - ha:
       skip_config_sync: true
+  - mp_cpu_utilization:
+      threshold: 40
   - planes_clock_sync:
       diff_threshold: 30
-  - dp_cpu_utilization:
-      threshold: 50
-      minutes: 2
   # tests below require additional configuration
   - arp_entry_exist:
       ip: "10.0.1.1"
@@ -869,6 +872,53 @@ the check to fail.
 Does not require configuration.
 
 **Method**: [`CheckFirewall.check_non_finished_jobs()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_non_finished_jobs)
+
+
+### `mp_cpu_utilization`
+
+This check examines the management plane CPU utilization for the last 1 minute and compares it against a threshold.
+
+**Method:** [`CheckFirewall.check_mp_cpu_utilization()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_mp_cpu_utilization)
+
+**Configuration parameters**
+
+parameter | description
+--- | ---
+`threshold` | (optional) Maximum acceptable CPU utilization percentage. Defaults to 80%.
+
+**Sample configuration**
+
+```mdx-code-block
+<Tabs>
+<TabItem value="python" label="Python" default>
+```
+
+```python showLineNumbers
+checks_configuration = [
+    {
+        'mp_cpu_utilization': {
+            'threshold': 75
+        }
+    }
+]
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="ansible" label="YAML">
+```
+
+```yaml showLineNumbers
+checks_configuration:
+  - mp_cpu_utilization:
+      threshold: 75
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
 
 ### `ntp_sync`
 

--- a/docs/panos-upgrade-assurance/configuration_details.mdx
+++ b/docs/panos-upgrade-assurance/configuration_details.mdx
@@ -274,7 +274,8 @@ checks_configuration = [
     {"expired_licenses": {"skip_licenses": ["Threat Prevention"]}},
     {'free_disk_space': {'image_version': '10.1.6-h6'}},
     {'ha': {'skip_config_sync': True}},
-    {'planes_clock_sync': {'diff_threshold': 30}}
+    {'planes_clock_sync': {'diff_threshold': 30}},
+    {'dp_cpu_utilization': {'threshold': 50, 'minutes': 2}},
     # tests below require additional configuration
     {'arp_entry_exist': {'ip': '10.0.1.1'} },
     {'ip_sec_tunnel_status': {
@@ -321,6 +322,9 @@ checks_configuration:
       skip_config_sync: true
   - planes_clock_sync:
       diff_threshold: 30
+  - dp_cpu_utilization:
+      threshold: 50
+      minutes: 2
   # tests below require additional configuration
   - arp_entry_exist:
       ip: "10.0.1.1"
@@ -517,6 +521,55 @@ checks_configuration = [
 checks_configuration:
   - content_version:
       version: '6453-5673'
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+
+### `dp_cpu_utilization`
+
+This check examines the data plane CPU utilization over a specified time period and compares it against a threshold.
+
+**Method:** [`CheckFirewall.check_dp_cpu_utilization()`](/panos/docs/panos-upgrade-assurance/api/check_firewall#checkfirewallcheck_dp_cpu_utilization)
+
+**Configuration parameters**
+
+parameter | description
+--- | ---
+`threshold` | (optional) Maximum acceptable average CPU utilization percentage. Defaults to 80%.
+`minutes` | (optional) Number of minutes to check, between 1 and 60. Defaults to 5 minutes.
+
+**Sample configuration**
+
+```mdx-code-block
+<Tabs>
+<TabItem value="python" label="Python" default>
+```
+
+```python showLineNumbers
+checks_configuration = [
+    {
+        'dp_cpu_utilization': {
+            'threshold': 90,
+            'minutes': 10
+        }
+    }
+]
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="ansible" label="YAML">
+```
+
+```yaml showLineNumbers
+checks_configuration:
+  - dp_cpu_utilization:
+      threshold: 90
+      minutes: 10
 ```
 
 ```mdx-code-block

--- a/examples/low_level_methods/run_low_level_methods.py
+++ b/examples/low_level_methods/run_low_level_methods.py
@@ -126,4 +126,6 @@ if __name__ == "__main__":
 
     print(f"\n  system environmentals: {firewall.get_system_environmentals()}")
 
+    print(f"\n  dp cpu utilization: {firewall.get_dp_cpu_utilization(minutes=2)}")
+
     print()

--- a/examples/low_level_methods/run_low_level_methods.py
+++ b/examples/low_level_methods/run_low_level_methods.py
@@ -128,4 +128,6 @@ if __name__ == "__main__":
 
     print(f"\n  dp cpu utilization: {firewall.get_dp_cpu_utilization(minutes=2)}")
 
+    print(f"\n  mp cpu utilization: {firewall.get_mp_cpu_utilization()}")
+
     print()

--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -105,6 +105,7 @@ if __name__ == "__main__":
         {"dynamic_updates": {"test_window": 500}},
         {"environmentals": {"components": ["power-supply"]}},
         {"dp_cpu_utilization": {"threshold": 50, "minutes": 2}},
+        {"mp_cpu_utilization": {"threshold": 10}},
         # checks below require additional configuration
         {
             "session_exist": {

--- a/examples/readiness_checks/run_readiness_checks.py
+++ b/examples/readiness_checks/run_readiness_checks.py
@@ -104,6 +104,7 @@ if __name__ == "__main__":
         },
         {"dynamic_updates": {"test_window": 500}},
         {"environmentals": {"components": ["power-supply"]}},
+        {"dp_cpu_utilization": {"threshold": 50, "minutes": 2}},
         # checks below require additional configuration
         {
             "session_exist": {

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -107,6 +107,7 @@ class CheckFirewall:
             CheckType.JOBS: self.check_non_finished_jobs,
             CheckType.GLOBAL_JUMBO_FRAME: self.check_global_jumbo_frame,
             CheckType.SYSTEM_ENVIRONMENTALS: self.check_system_environmentals,
+            CheckType.DP_CPU_UTILIZATION: self.check_dp_cpu_utilization,
         }
 
         self._health_check_method_mapping = {
@@ -1215,6 +1216,77 @@ class CheckFirewall:
             result.reason = f"Alarms detected in the following components: {', '.join(failed_components)}"
         else:
             result.status = CheckStatus.SUCCESS
+
+        return result
+
+    def check_dp_cpu_utilization(self, threshold: int = 80, minutes: int = 5) -> CheckResult:
+        """Check if the data plane CPU utilization is below a specified threshold.
+
+        This check retrieves the data plane CPU utilization for the specified duration and calculates the average CPU load
+        across all cores. If the average CPU load is below the threshold, the check passes.
+
+        # Parameters
+
+        threshold (int, optional): (defaults to 80) Maximum acceptable average CPU utilization percentage.
+        minutes (int, optional): (defaults to 5) Number of minutes to check, between 1 and 60.
+
+        # Raises
+
+        WrongDataTypeException: Raised when the threshold or minutes parameters are not integers.
+
+        # Returns
+
+        CheckResult: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking \
+            value of:
+
+        * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when average CPU utilization is below the threshold.
+        * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when average CPU utilization is equal to or above the threshold.
+        * [`CheckStatus.ERROR`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) when the data cannot be retrieved.
+
+        """
+        if not isinstance(threshold, int):
+            raise exceptions.WrongDataTypeException(f"Threshold parameter should be an integer, got {type(threshold)}")
+
+        if threshold < 0 or threshold > 100:
+            raise exceptions.WrongDataTypeException(f"Threshold parameter should be between 0 and 100, got {threshold}")
+
+        if not isinstance(minutes, int):
+            raise exceptions.WrongDataTypeException(f"Minutes parameter should be an integer, got {type(minutes)}")
+
+        if minutes < 1 or minutes > 60:
+            raise exceptions.WrongDataTypeException(f"Minutes parameter should be between 1 and 60, got {minutes}")
+
+        result = CheckResult()
+
+        try:
+            cpu_data = self._node.get_dp_cpu_utilization(minutes=minutes)
+        except Exception as e:
+            result.status = CheckStatus.ERROR
+            result.reason = f"Failed to retrieve data plane CPU utilization: {str(e)}"
+            return result
+
+        total_cpu = 0
+        total_samples = 0
+
+        # sum up the average CPU utilization across all cores and all values
+        for dp_name, dp_data in cpu_data.items():
+            for core_id, values in dp_data["cpu-load-average"].items():
+                total_cpu += sum(values)
+                total_samples += len(values)
+
+        if total_samples == 0:
+            result.status = CheckStatus.ERROR
+            result.reason = "No CPU utilization data available"
+            return result
+
+        avg_cpu = total_cpu / total_samples
+
+        if avg_cpu < threshold:
+            result.status = CheckStatus.SUCCESS
+        else:
+            result.reason = (
+                f"Average data plane CPU utilization ({avg_cpu:.2f}%) is above or equal to the threshold ({threshold}%)"
+            )
 
         return result
 

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1,4 +1,5 @@
 import re
+import ast
 import xml.etree.ElementTree as ET
 from panos_upgrade_assurance.utils import interpret_yes_no
 from xmltodict import parse as XMLParse
@@ -1718,6 +1719,7 @@ class FirewallProxy:
         # Raises
 
         WrongDataTypeException: Raised when the minutes parameter is not an integer or is outside the allowed range.
+        MalformedResponseException: Raised when response does not contain expected elements.
 
         # Returns
 
@@ -1771,3 +1773,52 @@ class FirewallProxy:
                 result[dp_name]["cpu-load-average"][core_id] = values
 
         return result
+
+    def get_mp_cpu_utilization(self) -> int:
+        """Get management plane CPU utilization for the last 1 minute.
+
+        The actual API command is `<show><system><state><filter>sys.monitor.*.mp.exports</filter></state></system></show>`.
+        MP state resides under s0 or s1 depending on the target firewall platform like `sys.monitor.s0.mp.exports` or
+        `sys.monitor.s1.mp.exports` so a wildcard is used to match any.
+
+        # Raises
+
+        MalformedResponseException: Raised when response does not contain expected elements or data format is invalid.
+
+        # Returns
+
+        int: Management plane CPU utilization percentage for the last 1 minute.
+
+        """
+        response = self.op_parser(
+            cmd="<show><system><state><filter>sys.monitor.*.mp.exports</filter></state></system></show>", cmd_in_xml=True
+        )
+        # command returns dict like data in CDATA section - sample response below with disks array removed
+        # <![CDATA[ sys.monitor.s0.mp.exports: { 'cpu': { '1minavg': 3, }, 'disks': [], 'slot': 0, } ]]>
+
+        if isinstance(response, str):
+            if "NO_MATCHES" in response:
+                raise exceptions.MalformedResponseException("No slots found with management plane data.")
+
+            # match data string for cpu - lazy match until first closing curly braces
+            match = re.search(r"'cpu':\s*(\{.*?\})", response)
+            if not match:
+                raise exceptions.MalformedResponseException("No match for management plane CPU data.")
+
+            # Convert the extracted string to a Python dict using eval
+            try:
+                data_str = match.group(1)
+                data = ast.literal_eval(data_str)
+            except Exception as e:
+                raise exceptions.MalformedResponseException(f"Failed to convert management plane CPU data to dict: {str(e)}")
+        else:
+            raise exceptions.MalformedResponseException("Unexpected response format for management plane CPU data.")
+
+        # Extract the CPU 1-minute average
+        try:
+            cpu_utilization = data.get("1minavg")
+            if cpu_utilization is None:
+                raise exceptions.MalformedResponseException("CPU utilization data not found in response.")
+            return int(cpu_utilization)
+        except (AttributeError, ValueError, TypeError) as e:
+            raise exceptions.MalformedResponseException(f"Failed to extract CPU utilization: {str(e)}")

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -35,6 +35,7 @@ class CheckType:
     GLOBAL_JUMBO_FRAME = "global_jumbo_frame"
     SYSTEM_ENVIRONMENTALS = "environmentals"
     DP_CPU_UTILIZATION = "dp_cpu_utilization"
+    MP_CPU_UTILIZATION = "mp_cpu_utilization"
 
 
 class SnapType:

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -34,6 +34,7 @@ class CheckType:
     JOBS = "jobs"
     GLOBAL_JUMBO_FRAME = "global_jumbo_frame"
     SYSTEM_ENVIRONMENTALS = "environmentals"
+    DP_CPU_UTILIZATION = "dp_cpu_utilization"
 
 
 class SnapType:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Implement data plane and management plane cpu readiness checks:

* `mp_cpu_utilization` readiness check implemented that checks if management plane
    cpu utilization passes a given threshold compared to average of last 1 minute.
* `dp_cpu_utilization` readiness check implemented that checks if dataplane cpu
    utilization passes a given threshold during the last X minutes.

## How Has This Been Tested?

Tested with unit tests.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
