### PR TITLE
fix: typing_extensions dependency on python <3.10

### DIFF
--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from copy import deepcopy
 from typing import Optional, Union, List, Iterable, Iterator
-from typing_extensions import TypeAlias
 from enum import Enum
 from panos_upgrade_assurance import exceptions
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:  # TypeAlias is added in python 3.10 so import from typing_extensions if python version is lower
+    from typing_extensions import TypeAlias
 
 
 class CheckType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pan-os-python = ">=1.8,<2.0"
 xmltodict = ">=0.12.0,<0.15.0"
 pyopenssl = ">=23.2,<24.0"
 packaging = ">=22.0"
+typing-extensions = { version = ">=4.13.2,<5.0", python = "<3.10" }
 
 [tool.poetry.group.dev.dependencies]
 flake8 = ">=5"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
typing_extensions added as a dependency when python version <3.10 since we are only using TypeAlias from typing_extensions which is added to typing in python 3.10. 
Import for TypeAlias updated according to the running python version.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was breaking when trying to import TypeAlias from typing_extensions for python >= 3.10 because typing_extensions is not a dependency but TypeAlias was being imported from typing_extensions.
Updated typing_extensions dependency according to the python version and also TypeAlias import is conditionally done from typing when python version is >3.10.
This also broke Docker image which is working with python 3.10.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with virtualenvs in different python versions.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
