### PR TITLE
fix: Planes Clock Sync when multiple dataplanes

### DIFF
--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -1056,7 +1056,7 @@ __Returns__
 ### `FirewallProxy.get_dp_clock`
 
 ```python
-def get_dp_clock() -> dict
+def get_dp_clock() -> List[datetime]
 ```
 
 Get the clock information from data plane.
@@ -1066,7 +1066,9 @@ The actual API command is `show clock more`.
 __Returns__
 
 
-`datetime`: The clock information represented as a `datetime` object.
+`List[datetime]`: The clock information represented as a list of `datetime` object.
+    As devices can have multiple dataplanes, this function returns the time of each dataplane clock if they are
+    different.
 
 ### `FirewallProxy.get_certificates`
 

--- a/examples/low_level_methods/run_low_level_methods.py
+++ b/examples/low_level_methods/run_low_level_methods.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
 
     print(f"\n  management plane clock:\n{firewall.get_mp_clock()}")
 
-    print(f"\n  data plane clock:\n{firewall.get_dp_clock()}")
+    print(f"\n  data plane clocks:\n{firewall.get_dp_clock()}")
 
     print(f"\n  certificates:\n{firewall.get_certificates()}")
 

--- a/panos_upgrade_assurance/__init__.py
+++ b/panos_upgrade_assurance/__init__.py
@@ -1,3 +1,7 @@
+import importlib.metadata
 from importlib import metadata
 
-__version__ = metadata.version(__package__)
+try:
+    __version__ = metadata.version(__package__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "devel"

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -802,7 +802,13 @@ class CheckFirewall:
         result = CheckResult()
 
         mp_clock = self._node.get_mp_clock()
-        dp_clock = self._node.get_dp_clock()
+        dp_clocks = self._node.get_dp_clock()
+
+        if len(dp_clocks) > 1:
+            result.reason = "Time values between dataplane clocks are different."
+            return result
+
+        dp_clock = dp_clocks[0]
 
         time_fluctuation = abs((mp_clock - dp_clock).total_seconds())
         if time_fluctuation > diff_threshold:

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -3,7 +3,7 @@ import ast
 import xml.etree.ElementTree as ET
 from panos_upgrade_assurance.utils import interpret_yes_no
 from xmltodict import parse as XMLParse
-from typing import Optional, Union
+from typing import Optional, Union, List
 from panos.firewall import Firewall
 from pan.xapi import PanXapiError
 from panos_upgrade_assurance import exceptions
@@ -1214,15 +1214,16 @@ class FirewallProxy:
 
         return dt
 
-    def get_dp_clock(self) -> list[datetime]:
+    def get_dp_clock(self) -> List[datetime]:
         """Get the clock information from data plane.
 
         The actual API command is `show clock more`.
 
         # Returns
 
-        datetime: The clock information represented as a `datetime` object. As devices can have multiple dataplanes,
-            this function returns the time of each dataplane clock if they are different.
+        List[datetime]: The clock information represented as a list of `datetime` object.
+            As devices can have multiple dataplanes, this function returns the time of each dataplane clock if they are
+            different.
         """
         response = self.op_parser(cmd="show clock more")
         time_string = dict(response)["member"]

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1214,33 +1214,44 @@ class FirewallProxy:
 
         return dt
 
-    def get_dp_clock(self) -> dict:
+    def get_dp_clock(self) -> list[datetime]:
         """Get the clock information from data plane.
 
         The actual API command is `show clock more`.
 
         # Returns
 
-        datetime: The clock information represented as a `datetime` object.
-
+        datetime: The clock information represented as a `datetime` object. As devices can have multiple dataplanes,
+            this function returns the time of each dataplane clock if they are different.
         """
         response = self.op_parser(cmd="show clock more")
         time_string = dict(response)["member"]
-        time_parsed = time_string.split()
-        time_dict = {
-            "time": time_parsed[5],
-            "tz": time_parsed[6],
-            "day": time_parsed[4],
-            "month": time_parsed[3],
-            "year": time_parsed[7],
-            "day_of_week": time_parsed[2],
-        }
-        dt = datetime.strptime(
-            f"{time_dict['year']}-{time_dict['month']}-{time_dict['day']} {time_dict['time']}",
-            "%Y-%b-%d %H:%M:%S",
-        )
+        time_string_lines = time_string.split("\n")
 
-        return dt
+        found_times = set()
+        for line in time_string_lines:
+            if "dataplane time" in line.lower():
+                found_times.add(line)
+
+        result = []
+
+        for found_time in found_times:
+            time_parsed = found_time.split()
+            time_dict = {
+                "time": time_parsed[5],
+                "tz": time_parsed[6],
+                "day": time_parsed[4],
+                "month": time_parsed[3],
+                "year": time_parsed[7],
+                "day_of_week": time_parsed[2],
+            }
+            dt = datetime.strptime(
+                f"{time_dict['year']}-{time_dict['month']}-{time_dict['day']} {time_dict['time']}",
+                "%Y-%b-%d %H:%M:%S",
+            )
+            result.append(dt)
+
+        return result
 
     def get_certificates(self) -> dict:
         """Get information about certificates installed on a device.

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -1109,9 +1109,9 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = datetime.strptime(
+        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
             "Wed May 31 11:52:34 2023", "%a %b %d %H:%M:%S %Y"
-        )
+        )]
 
         assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(
             status=CheckStatus.FAIL, reason="The data plane clock and management clock are different by 133.0 seconds."
@@ -1121,9 +1121,9 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = datetime.strptime(
+        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
             "Wed May 31 11:50:34 2023", "%a %b %d %H:%M:%S %Y"
-        )
+        )]
 
         assert check_firewall_mock.check_mp_dp_sync(30) == CheckResult(status=CheckStatus.SUCCESS)
 
@@ -1131,11 +1131,29 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = datetime.strptime(
+        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
-        )
+        )]
 
         assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(status=CheckStatus.SUCCESS)
+
+    def test_check_mp_dp_sync_dp_clocks_not_sync(self, check_firewall_mock):
+        check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
+            "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
+        )
+        check_firewall_mock._node.get_dp_clock.return_value = [
+            datetime.strptime(
+            "Wed May 30 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
+            ),
+            datetime.strptime(
+                "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
+            )
+        ]
+
+        assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(
+            status=CheckStatus.FAIL,
+            reason="Time values between dataplane clocks are different."
+        )
 
     @pytest.mark.parametrize(
         "param_rsa, param_ecdsa, exc_msg",

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -1143,7 +1143,7 @@ class TestCheckFirewall:
         )
         check_firewall_mock._node.get_dp_clock.return_value = [
             datetime.strptime(
-            "Wed May 30 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
+                "Wed May 30 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
             ),
             datetime.strptime(
                 "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -1109,9 +1109,9 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
-            "Wed May 31 11:52:34 2023", "%a %b %d %H:%M:%S %Y"
-        )]
+        check_firewall_mock._node.get_dp_clock.return_value = [
+            datetime.strptime("Wed May 31 11:52:34 2023", "%a %b %d %H:%M:%S %Y")
+        ]
 
         assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(
             status=CheckStatus.FAIL, reason="The data plane clock and management clock are different by 133.0 seconds."
@@ -1121,9 +1121,9 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
-            "Wed May 31 11:50:34 2023", "%a %b %d %H:%M:%S %Y"
-        )]
+        check_firewall_mock._node.get_dp_clock.return_value = [
+            datetime.strptime("Wed May 31 11:50:34 2023", "%a %b %d %H:%M:%S %Y")
+        ]
 
         assert check_firewall_mock.check_mp_dp_sync(30) == CheckResult(status=CheckStatus.SUCCESS)
 
@@ -1131,9 +1131,9 @@ class TestCheckFirewall:
         check_firewall_mock._node.get_mp_clock.return_value = datetime.strptime(
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
-        check_firewall_mock._node.get_dp_clock.return_value = [datetime.strptime(
-            "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
-        )]
+        check_firewall_mock._node.get_dp_clock.return_value = [
+            datetime.strptime("Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y")
+        ]
 
         assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(status=CheckStatus.SUCCESS)
 
@@ -1142,17 +1142,12 @@ class TestCheckFirewall:
             "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
         )
         check_firewall_mock._node.get_dp_clock.return_value = [
-            datetime.strptime(
-                "Wed May 30 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
-            ),
-            datetime.strptime(
-                "Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"
-            )
+            datetime.strptime("Wed May 30 11:50:21 2023", "%a %b %d %H:%M:%S %Y"),
+            datetime.strptime("Wed May 31 11:50:21 2023", "%a %b %d %H:%M:%S %Y"),
         ]
 
         assert check_firewall_mock.check_mp_dp_sync(1) == CheckResult(
-            status=CheckStatus.FAIL,
-            reason="Time values between dataplane clocks are different."
+            status=CheckStatus.FAIL, reason="Time values between dataplane clocks are different."
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1597,7 +1597,10 @@ class TestFirewallProxy:
         first_time = datetime.strptime("Sun Mar 22 19:19:10 2026", "%a %b %d %H:%M:%S %Y")
         second_time = datetime.strptime("Sun Mar 23 19:19:10 2026", "%a %b %d %H:%M:%S %Y")
 
-        assert fw_proxy_mock.get_dp_clock() == [first_time, second_time]
+        result = fw_proxy_mock.get_dp_clock()
+        assert first_time in result
+        assert second_time in result
+        assert len(result) == 2
 
     def test_get_jobs(self, fw_proxy_mock):
         xml_text = """

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1546,7 +1546,7 @@ class TestFirewallProxy:
 
         response = datetime.strptime("Wed May 31 11:52:34 2023", "%a %b %d %H:%M:%S %Y")
 
-        assert fw_proxy_mock.get_dp_clock() == response
+        assert fw_proxy_mock.get_dp_clock() == [response]
 
     def test_get_dp_clock_alt_format_all_in_sync(self, fw_proxy_mock):
         """Test the get_dp_clock function returns a single item list when there's only one dataplane to worry about

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1555,13 +1555,13 @@ class TestFirewallProxy:
         <response status="success">
             <result>
                 <member>DP s3dp0:
-        
+
         dataplane time: Sun Mar 22 19:19:10 PDT 2026
-        
-        
-        
+
+
+
         DP s3dp1:
-        
+
         dataplane time: Sun Mar 22 19:19:10 PDT 2026
                 </member>
             </result>

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -1548,6 +1548,57 @@ class TestFirewallProxy:
 
         assert fw_proxy_mock.get_dp_clock() == response
 
+    def test_get_dp_clock_alt_format_all_in_sync(self, fw_proxy_mock):
+        """Test the get_dp_clock function returns a single item list when there's only one dataplane to worry about
+        and the clocks are in sync"""
+        xml_text = """
+        <response status="success">
+            <result>
+                <member>DP s3dp0:
+        
+        dataplane time: Sun Mar 22 19:19:10 PDT 2026
+        
+        
+        
+        DP s3dp1:
+        
+        dataplane time: Sun Mar 22 19:19:10 PDT 2026
+                </member>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        response = datetime.strptime("Sun Mar 22 19:19:10 2026", "%a %b %d %H:%M:%S %Y")
+
+        assert fw_proxy_mock.get_dp_clock() == [response]
+
+    def test_get_dp_clock_alt_format_out_of_sync(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <member>DP s3dp0:
+
+        dataplane time: Sun Mar 22 19:19:10 PDT 2026
+
+
+
+        DP s3dp1:
+
+        dataplane time: Sun Mar 23 19:19:10 PDT 2026
+                </member>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        first_time = datetime.strptime("Sun Mar 22 19:19:10 2026", "%a %b %d %H:%M:%S %Y")
+        second_time = datetime.strptime("Sun Mar 23 19:19:10 2026", "%a %b %d %H:%M:%S %Y")
+
+        assert fw_proxy_mock.get_dp_clock() == [first_time, second_time]
+
     def test_get_jobs(self, fw_proxy_mock):
         xml_text = """
         <response status="success">


### PR DESCRIPTION
Fixes #191 

## description

This PR changes the behavior of the `get_dp_clock()` function to parse all of the dataclock reported times from the `show clock more` command. For devices with multiple dataplanes, each one has it's own clock and so the output is different.

In addition, the `check_mp_dp_sync` function now checks that the dataplane clocks are in sync with each other, as well as in sync with the management plane.