### PR TITLE
feat: Check for config locks

### DIFF
--- a/docs/panos-upgrade-assurance/api/check_firewall.md
+++ b/docs/panos-upgrade-assurance/api/check_firewall.md
@@ -1056,3 +1056,20 @@ __Returns__
 * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) if the device is not affected,
 * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) otherwise.
 
+### `CheckFirewall.check_config_locks`
+
+```python
+def check_config_locks()
+```
+
+Checks for the prescence of configuration locks on the system. A locked configuration implies an
+administrator is actively working on the device.
+
+__Returns__
+
+
+`CheckResult`: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking             value of:
+
+* [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) if the device is not affected,
+* [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) otherwise.
+

--- a/docs/panos-upgrade-assurance/api/firewall_proxy.md
+++ b/docs/panos-upgrade-assurance/api/firewall_proxy.md
@@ -1837,3 +1837,30 @@ __Returns__
 }
 ```
 
+### `FirewallProxy.get_config_locks`
+
+```python
+def get_config_locks() -> list[dict]
+```
+
+Get configuration lock details from the device.
+
+__Returns__
+
+
+A list of config lock detail dictionaries
+
+```python showLineNumbers title="Sample output"
+[
+    {
+        '@name': 'admin',
+        'type': 'shared',
+        'name': 'shared',
+        'created': '2026/03/19 17:00:45',
+        'last-activity': '2026/03/19 17:00:45',
+        'loggedin': 'yes',
+        'comment': 'Testing config lock api'
+    }
+]
+```
+

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -120,6 +120,7 @@ class CheckFirewall:
             CheckType.SYSTEM_ENVIRONMENTALS: self.check_system_environmentals,
             CheckType.DP_CPU_UTILIZATION: self.check_dp_cpu_utilization,
             CheckType.MP_CPU_UTILIZATION: self.check_mp_cpu_utilization,
+            CheckType.CONFIG_LOCKS: self.check_config_locks,
         }
 
         self._health_check_method_mapping = {

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -2005,8 +2005,7 @@ class CheckFirewall:
 
         return result
 
-
-    def check_config_locks(self):
+    def check_config_locks(self) -> CheckResult:
         """Checks for the prescence of configuration locks on the system. A locked configuration implies an
         administrator is actively working on the device.
 

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -2019,11 +2019,20 @@ class CheckFirewall:
 
         """
         result = CheckResult()
-        locks = self._node.get_config_locks()
-        if not locks:
+        config_locks = self._node.get_config_locks()
+        commit_locks = self._node.get_commit_locks()
+        if not config_locks + commit_locks:
             result.status = CheckStatus.SUCCESS
             return result
 
-        result.reason = f"Configuration is currently locked by {', '.join([i.get('@name') for i in locks])}"
-        result.status = CheckStatus.FAIL
+        reason = ""
+        if config_locks:
+            reason += f"Configuration is currently locked by {', '.join([i.get('@name') for i in config_locks])}. "
+            result.status = CheckStatus.FAIL
+
+        if commit_locks:
+            reason += f"Commits are currently locked by {', '.join([i.get('@name') for i in commit_locks])}."
+            result.status = CheckStatus.FAIL
+
+        result.reason = reason
         return result

--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -2004,3 +2004,27 @@ class CheckFirewall:
         )
 
         return result
+
+
+    def check_config_locks(self):
+        """Checks for the prescence of configuration locks on the system. A locked configuration implies an
+        administrator is actively working on the device.
+
+        # Returns
+
+        CheckResult: Object of [`CheckResult`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkresult) class taking \
+            value of:
+
+        * [`CheckStatus.SUCCESS`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) if the device is not affected,
+        * [`CheckStatus.FAIL`](/panos/docs/panos-upgrade-assurance/api/utils#class-checkstatus) otherwise.
+
+        """
+        result = CheckResult()
+        locks = self._node.get_config_locks()
+        if not locks:
+            result.status = CheckStatus.SUCCESS
+            return result
+
+        result.reason = f"Configuration is currently locked by {', '.join([i.get('@name') for i in locks])}"
+        result.status = CheckStatus.FAIL
+        return result

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -2206,3 +2206,42 @@ class FirewallProxy:
             raise exceptions.MalformedResponseException("sw.dev.interface.config system state data not found in response")
 
         return result
+
+    def get_config_locks(self) -> list[dict]:
+        """
+        Get configuration lock details from the device.
+
+        # Returns
+
+        A list of config lock detail dictionaries
+
+        ```python showLineNumbers title="Sample output"
+        [
+            {
+                '@name': 'admin',
+                'type': 'shared',
+                'name': 'shared',
+                'created': '2026/03/19 17:00:45',
+                'last-activity': '2026/03/19 17:00:45',
+                'loggedin': 'yes',
+                'comment': 'Testing config lock api'
+            }
+        ]
+        ```
+
+        """
+
+        # Get parent interfaces and their MTUs using `show system state filter sw.dev.interface.config`
+        response = self.op_parser(
+            cmd="<show><config-locks><vsys>all</vsys></config-locks></show>",
+            cmd_in_xml=True
+        )
+        locks = response.get("config-locks")
+        if locks:
+            entries = locks.get("entry")
+            if isinstance(entries, dict):
+                return [entries]
+
+            return entries
+
+        return []

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -2232,10 +2232,7 @@ class FirewallProxy:
         """
 
         # Get parent interfaces and their MTUs using `show system state filter sw.dev.interface.config`
-        response = self.op_parser(
-            cmd="<show><config-locks><vsys>all</vsys></config-locks></show>",
-            cmd_in_xml=True
-        )
+        response = self.op_parser(cmd="<show><config-locks><vsys>all</vsys></config-locks></show>", cmd_in_xml=True)
         locks = response.get("config-locks")
         if locks:
             entries = locks.get("entry")

--- a/panos_upgrade_assurance/firewall_proxy.py
+++ b/panos_upgrade_assurance/firewall_proxy.py
@@ -1,5 +1,6 @@
 import re
 import ast
+import enum
 import xml.etree.ElementTree as ET
 from panos_upgrade_assurance.utils import interpret_yes_no
 from xmltodict import parse as XMLParse
@@ -10,6 +11,11 @@ from panos_upgrade_assurance import exceptions
 from math import floor
 from datetime import datetime, timedelta
 from packaging import version
+
+
+class LockType(str, enum.Enum):
+    commit_lock = "commit-locks"
+    config_lock = "config-locks"
 
 
 class FirewallProxy:
@@ -2207,6 +2213,20 @@ class FirewallProxy:
 
         return result
 
+    def get_locks_by_type(self, lock_type: LockType):
+        """Helper function to make it easy to get locks by a given type"""
+        lock_type_str = lock_type.value
+        response = self.op_parser(cmd=f"<show><{lock_type_str}><vsys>all</vsys></{lock_type_str}></show>", cmd_in_xml=True)
+        locks = response.get(lock_type_str)
+        if locks:
+            entries = locks.get("entry")
+            if isinstance(entries, dict):
+                return [entries]
+
+            return entries
+
+        return []
+
     def get_config_locks(self) -> list[dict]:
         """
         Get configuration lock details from the device.
@@ -2231,14 +2251,30 @@ class FirewallProxy:
 
         """
 
-        # Get parent interfaces and their MTUs using `show system state filter sw.dev.interface.config`
-        response = self.op_parser(cmd="<show><config-locks><vsys>all</vsys></config-locks></show>", cmd_in_xml=True)
-        locks = response.get("config-locks")
-        if locks:
-            entries = locks.get("entry")
-            if isinstance(entries, dict):
-                return [entries]
+        return self.get_locks_by_type(LockType.config_lock)
 
-            return entries
+    def get_commit_locks(self) -> list[dict]:
+        """
+        Get commit lock details from the device
 
-        return []
+        # Returns
+
+        A list of config lock detail dictionaries
+
+        ```python showLineNumbers title="Sample output"
+        [
+            {
+                '@name': 'admin',
+                'type': 'shared',
+                'name': 'shared',
+                'created': '2026/03/19 17:00:45',
+                'last-activity': '2026/03/19 17:00:45',
+                'loggedin': 'yes',
+                'comment': 'Testing config lock api'
+            }
+        ]
+        ```
+
+        """
+
+        return self.get_locks_by_type(LockType.commit_lock)

--- a/panos_upgrade_assurance/utils.py
+++ b/panos_upgrade_assurance/utils.py
@@ -41,6 +41,7 @@ class CheckType:
     SYSTEM_ENVIRONMENTALS = "environmentals"
     DP_CPU_UTILIZATION = "dp_cpu_utilization"
     MP_CPU_UTILIZATION = "mp_cpu_utilization"
+    CONFIG_LOCKS = "config_locks"
 
 
 class SnapType:

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -2068,13 +2068,13 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
     def test_check_config_locks_config_locked(self, check_firewall_mock):
         check_firewall_mock._node.get_config_locks.return_value = [
             {
-                '@name': 'admin',
-                'type': 'shared',
-                'name': 'shared',
-                'created': '2026/03/19 17:00:45',
-                'last-activity': '2026/03/19 17:00:45',
-                'loggedin': 'yes',
-                'comment': 'Testing config lock api'
+                "@name": "admin",
+                "type": "shared",
+                "name": "shared",
+                "created": "2026/03/19 17:00:45",
+                "last-activity": "2026/03/19 17:00:45",
+                "loggedin": "yes",
+                "comment": "Testing config lock api",
             }
         ]
 

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -2064,3 +2064,29 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
         check_firewall_mock._node.get_system_time_rebooted = MagicMock(return_value=last_reboot)
 
         assert check_firewall_mock.check_cdss_and_panorama_certificate_issue().status == expected_status
+
+    def test_check_config_locks_config_locked(self, check_firewall_mock):
+        check_firewall_mock._node.get_config_locks.return_value = [
+            {
+                '@name': 'admin',
+                'type': 'shared',
+                'name': 'shared',
+                'created': '2026/03/19 17:00:45',
+                'last-activity': '2026/03/19 17:00:45',
+                'loggedin': 'yes',
+                'comment': 'Testing config lock api'
+            }
+        ]
+
+        result = check_firewall_mock.check_config_locks()
+
+        assert result.status == CheckStatus.FAIL
+        assert "Configuration is currently locked by admin" in result.reason
+
+    def test_check_config_locks_config_is_not_locked(self, check_firewall_mock):
+        check_firewall_mock._node.get_config_locks.return_value = []
+
+        result = check_firewall_mock.check_config_locks()
+
+        assert result.status == CheckStatus.SUCCESS
+        assert not result.reason

--- a/tests/test_check_firewall.py
+++ b/tests/test_check_firewall.py
@@ -2077,14 +2077,35 @@ UT1F7XqZcTWaThXLFMpQyUvUpuhilcmzucrvVI0=
                 "comment": "Testing config lock api",
             }
         ]
+        check_firewall_mock._node.get_commit_locks.return_value = []
 
         result = check_firewall_mock.check_config_locks()
 
         assert result.status == CheckStatus.FAIL
-        assert "Configuration is currently locked by admin" in result.reason
+        assert "Configuration is currently locked by admin. " in result.reason
+
+    def test_check_config_locks_commit_locked(self, check_firewall_mock):
+        check_firewall_mock._node.get_commit_locks.return_value = [
+            {
+                "@name": "admin",
+                "type": "shared",
+                "name": "shared",
+                "created": "2026/03/19 17:00:45",
+                "last-activity": "2026/03/19 17:00:45",
+                "loggedin": "yes",
+                "comment": "Testing commit lock api",
+            }
+        ]
+        check_firewall_mock._node.get_config_locks.return_value = []
+
+        result = check_firewall_mock.check_config_locks()
+
+        assert result.status == CheckStatus.FAIL
+        assert "Commits are currently locked by admin." in result.reason
 
     def test_check_config_locks_config_is_not_locked(self, check_firewall_mock):
         check_firewall_mock._node.get_config_locks.return_value = []
+        check_firewall_mock._node.get_commit_locks.return_value = []
 
         result = check_firewall_mock.check_config_locks()
 

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -3236,3 +3236,50 @@ class TestFirewallProxy:
         with pytest.raises(MalformedResponseException) as exc_info:
             fw_proxy_mock.get_are_routes()
         assert "Failed to decode JSON response" in str(exc_info.value)
+
+    def test_get_config_locks(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <config-locks>
+                    <entry name="admin">
+                        <type>shared</type>
+                        <name>shared</name>
+                        <created>2026/03/19 17:00:45</created>
+                        <last-activity>2026/03/19 17:00:45</last-activity>
+                        <loggedin>yes</loggedin>
+                        <comment>
+                            <![CDATA[Testing config lock api]]>
+                        </comment>
+                    </entry>
+                </config-locks>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_config_locks() == [
+            {
+                '@name': 'admin',
+                'type': 'shared',
+                'name': 'shared',
+                'created': '2026/03/19 17:00:45',
+                'last-activity': '2026/03/19 17:00:45',
+                'loggedin': 'yes',
+                'comment': 'Testing config lock api'
+            }
+        ]
+
+    def test_get_config_locks_no_locks(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <config-locks></config-locks>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_config_locks() == []

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -3261,13 +3261,13 @@ class TestFirewallProxy:
 
         assert fw_proxy_mock.get_config_locks() == [
             {
-                '@name': 'admin',
-                'type': 'shared',
-                'name': 'shared',
-                'created': '2026/03/19 17:00:45',
-                'last-activity': '2026/03/19 17:00:45',
-                'loggedin': 'yes',
-                'comment': 'Testing config lock api'
+                "@name": "admin",
+                "type": "shared",
+                "name": "shared",
+                "created": "2026/03/19 17:00:45",
+                "last-activity": "2026/03/19 17:00:45",
+                "loggedin": "yes",
+                "comment": "Testing config lock api",
             }
         ]
 

--- a/tests/test_firewall_proxy.py
+++ b/tests/test_firewall_proxy.py
@@ -3283,3 +3283,50 @@ class TestFirewallProxy:
         fw_proxy_mock.op.return_value = raw_response
 
         assert fw_proxy_mock.get_config_locks() == []
+
+    def test_get_config_locks(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <commit-locks>
+                    <entry name="admin">
+                        <type>shared</type>
+                        <name>shared</name>
+                        <created>2026/03/19 17:00:45</created>
+                        <last-activity>2026/03/19 17:00:45</last-activity>
+                        <loggedin>yes</loggedin>
+                        <comment>
+                            <![CDATA[Testing commit lock api]]>
+                        </comment>
+                    </entry>
+                </commit-locks>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_commit_locks() == [
+            {
+                "@name": "admin",
+                "type": "shared",
+                "name": "shared",
+                "created": "2026/03/19 17:00:45",
+                "last-activity": "2026/03/19 17:00:45",
+                "loggedin": "yes",
+                "comment": "Testing commit lock api",
+            }
+        ]
+
+    def test_get_commit_locks_no_locks(self, fw_proxy_mock):
+        xml_text = """
+        <response status="success">
+            <result>
+                <commit-locks></commit-locks>
+            </result>
+        </response>
+        """
+        raw_response = ET.fromstring(xml_text)
+        fw_proxy_mock.op.return_value = raw_response
+
+        assert fw_proxy_mock.get_commit_locks() == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ from panos_upgrade_assurance.utils import ConfigParser, CheckType, SnapType, int
 from deepdiff import DeepDiff
 from panos_upgrade_assurance.exceptions import WrongDataTypeException, UnknownParameterException
 
-
 valid_check_types = [v for k, v in vars(CheckType).items() if not k.startswith("__")]
 valid_snap_types = [v for k, v in vars(SnapType).items() if not k.startswith("__")]
 


### PR DESCRIPTION
Implements #192 

Provides a readiness test for checking configuration locks on PAN-OS firewalls (or panorama).

This has been tested on both single and multi-vsys firewalls and supports config locks and commit locks.

The test fails if any lock is present and the reason includes the administrators that have requested the lock.