### PR TITLE
fix: check schedule now works correctly when threshold in use #202

### DIFF
--- a/panos_upgrade_assurance/check_firewall.py
+++ b/panos_upgrade_assurance/check_firewall.py
@@ -1080,7 +1080,7 @@ class CheckFirewall:
 
                 # let's get rid of all keys that are not related to a schedule
                 for k in list(schedule_details.keys()):
-                    if k in ["sync-to-peer", "threshold"] or k.startswith("@"):
+                    if k in ["sync-to-peer", "threshold", "new-app-threshold"] or k.startswith("@"):
                         schedule_details.pop(k)
 
                 # we now should have a single element dict


### PR DESCRIPTION
Fixes a small bug when there is an extraneous key returned by the get schedule function, owing to the configuration of a threshold for new apps in the schedule 