### PR TITLE
ci: fix pydoc-markdown databind distribution not found issue

### DIFF
--- a/.github/workflows/sub_docs.yml
+++ b/.github/workflows/sub_docs.yml
@@ -49,6 +49,25 @@ jobs:
           python -m pip install --upgrade setuptools
           pip install -r requirements-docs.txt
 
+      - name: Fix databind package names for pkg_resources compatibility
+        run: |
+          SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+          cd "$SITE_PACKAGES"
+
+          # Create symlinks for databind packages with dots (databind.json, databind.core)
+          # to fix pkg_resources compatibility issue in older Python versions
+          for pkg in databind_json databind_core; do
+            for dir in ${pkg}-*.dist-info; do
+              if [ -d "$dir" ]; then
+                dotted_name=$(echo "$dir" | sed "s/${pkg}/$(echo $pkg | tr '_' '.')/" )
+                if [ ! -e "$dotted_name" ]; then
+                  echo "Creating symlink: $dotted_name -> $dir"
+                  ln -s "$dir" "$dotted_name"
+                fi
+              fi
+            done
+          done
+
       - name: Generate API docs
         run: make documentation
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
fixing the github actions issue for documentation check:

```
     pkg_resources.DistributionNotFound: The 'databind.core<5.0.0,>=4.4.0' distribution was not found and is required by the
     application
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
