### PR TITLE
feat: Update dependencies and drop python 3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
 "Bug Tracker" = "https://github.com/PaloAltoNetworks/pan-os-upgrade-assurance/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9.2"
 pan-os-python = ">=1.8,<2.0"
 xmltodict = ">=0.12.0,<0.15.0"
-pyopenssl = ">=23.2,<24.0"
+pyopenssl = "^26.0.0"
 packaging = ">=22.0"
 typing-extensions = { version = ">=4.13.2,<5.0", python = "<3.10" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9.2"
 pan-os-python = ">=1.8,<2.0"
-xmltodict = ">=0.12.0,<0.15.0"
+xmltodict = "^1.0.4"
 pyopenssl = "^26.0.0"
 packaging = ">=22.0"
 typing-extensions = { version = ">=4.13.2,<5.0", python = "<3.10" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9.2"
 pan-os-python = ">=1.8,<2.0"
-xmltodict = "^1.0.4"
-pyopenssl = "^26.0.0"
+xmltodict = ">=1.0.4,<2.0.0"
+pyopenssl = ">=26.0.0,<27.0.0"
 packaging = ">=22.0"
 typing-extensions = { version = ">=4.13.2,<5.0", python = "<3.10" }
 


### PR DESCRIPTION
This PR drops support for python 3.8, and in doing so, allows for the update of the following packages;

* `xmltodict`
* `pyopenssl`

Both of which require `python>=3.9.2`.

Because even python 3.9 is EOL at this stage I think this is fine to release as a minor release, and is not considered a breaking change.